### PR TITLE
feat: Additional MQTT commands

### DIFF
--- a/yoto_api/YotoAPI.py
+++ b/yoto_api/YotoAPI.py
@@ -32,21 +32,21 @@ class YotoAPI:
             "username": username,
             "scope": "openid email profile offline_access",
         }
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded"
-        }
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
 
         response = requests.post(url, data=data, headers=headers).json()
         _LOGGER.debug(f"{DOMAIN} - Sign In Response {response}")
 
-        valid_until = datetime.datetime.now(pytz.utc) + datetime.timedelta(seconds=response["expires_in"])
+        valid_until = datetime.datetime.now(pytz.utc) + datetime.timedelta(
+            seconds=response["expires_in"]
+        )
 
         return Token(
             access_token=response["access_token"],
             refresh_token=response["refresh_token"],
             token_type=response["token_type"],
             scope=response["scope"],
-            valid_until=valid_until
+            valid_until=valid_until,
         )
 
     # https://api.yoto.dev/#644d0b20-0b27-4b34-bbfa-bdffb96ec672
@@ -57,15 +57,15 @@ class YotoAPI:
             "grant_type": "refresh_token",
             "refresh_token": token.refresh_token,
         }
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded"
-        }
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
 
         response = requests.post(url, data=data, headers=headers).json()
         _LOGGER.debug(f"{DOMAIN} - Refresh TokenResponse {response}")
-        
-        valid_until = datetime.datetime.now(pytz.utc) + timedelta(seconds=response["expires_in"])
-        
+
+        valid_until = datetime.datetime.now(pytz.utc) + timedelta(
+            seconds=response["expires_in"]
+        )
+
         return Token(
             access_token=response["access_token"],
             refresh_token=token.refresh_token,

--- a/yoto_api/YotoMQTTClient.py
+++ b/yoto_api/YotoMQTTClient.py
@@ -63,9 +63,7 @@ class YotoMQTTClient:
 
     def set_volume(self, deviceId: str, volume: int):
         topic = f"device/{deviceId}/command/set-volume"
-        payload = {
-            "volume": volume
-        }
+        payload = {"volume": volume}
         self.client.publish(topic, str(payload))
         # {"status":{"set-volume":"OK","req_body":"{\"volume\":25,\"requestId\":\"39804a13-988d-43d2-b30f-1f3b9b5532f0\"}"}}
 
@@ -80,10 +78,16 @@ class YotoMQTTClient:
     def card_resume(self, deviceId):
         topic = f"device/{deviceId}/command/card-resume"
         self.client.publish(topic)
-        # MQTT Message: {"status":{"card-pause":"OK","req_body":""}}  
+        # MQTT Message: {"status":{"card-pause":"OK","req_body":""}}
 
     def card_play(
-        self, deviceId, cardId: str, secondsIn: int, cutoff: int, chapterKey: str, trackKey: str
+        self,
+        deviceId,
+        cardId: str,
+        secondsIn: int,
+        cutoff: int,
+        chapterKey: str,
+        trackKey: str,
     ):
         topic = f"device/{deviceId}/command/card-play"
         payload = {
@@ -101,14 +105,10 @@ class YotoMQTTClient:
         topic = f"device/{deviceId}/command/restart"
         self.client.publish(topic)
 
-     # set the ambient light of the player
+    # set the ambient light of the player
     def ambients(self, deviceId, r: int, g: int, b: int):
         topic = f"device/{deviceId}/command/ambients"
-        payload = {
-            "r": r,
-            "g": g,
-            "b": b
-        }
+        payload = {"r": r, "g": g, "b": b}
         self.client.publish(topic, str(payload))
 
     def _parse_status_message(self, message, player):

--- a/yoto_api/YotoMQTTClient.py
+++ b/yoto_api/YotoMQTTClient.py
@@ -57,39 +57,59 @@ class YotoMQTTClient:
         self.flag_connected = 0
         _LOGGER.debug(f"{DOMAIN} - MQTT Disconnected: {rc}")
 
-    def card_pause(self, deviceId):
-        topic = "device/" + deviceId + "/command/card-pause"
-        payload = ""
-        self._publish_command(topic, payload)
-
     def update_status(self, deviceId):
-        topic = "device/" + deviceId + "/command/events"
-        payload = ""
-        self._publish_command(topic, payload)
+        topic = f"device/{deviceId}/command/events"
+        self.client.publish(topic)
 
     def set_volume(self, deviceId: str, volume: int):
-        topic = "device/" + deviceId + "/command/set-volume"
-        payload = {}
-        payload["volume"] = volume
-        payload = str(payload)
-        self._publish_command(topic, payload)
+        topic = f"device/{deviceId}/command/set-volume"
+        payload = {
+            "volume": volume
+        }
+        self.client.publish(topic, str(payload))
         # {"status":{"set-volume":"OK","req_body":"{\"volume\":25,\"requestId\":\"39804a13-988d-43d2-b30f-1f3b9b5532f0\"}"}}
 
+    def card_stop(self, deviceId):
+        topic = f"device/{deviceId}/command/card-stop"
+        self.client.publish(topic)
+
+    def card_pause(self, deviceId):
+        topic = f"device/{deviceId}/command/card-pause"
+        self.client.publish(topic)
+
     def card_resume(self, deviceId):
-        topic = "device/" + deviceId + "/command/card-resume"
-        payload = ""
-        self._publish_command(topic, payload)
-        # MQTT Message: {"status":{"card-pause":"OK","req_body":""}}
+        topic = f"device/{deviceId}/command/card-resume"
+        self.client.publish(topic)
+        # MQTT Message: {"status":{"card-pause":"OK","req_body":""}}  
 
     def card_play(
-        self, deviceId, card: str, secondsIn: int, cutoff: int, chapterKey: int
+        self, deviceId, cardId: str, secondsIn: int, cutoff: int, chapterKey: str, trackKey: str
     ):
-        topic = "device/" + deviceId + "/command/card-play"
-        self._publish_command(topic, "card-play")
+        topic = f"device/{deviceId}/command/card-play"
+        payload = {
+            "uri": f"https://yoto.io/{cardId}",
+            "chapterKey": chapterKey,
+            "trackKey": trackKey,
+            "secondsIn": secondsIn,
+            "cutOff": cutoff,
+        }
+        self.client.publish(topic, str(payload))
         # MQTT Message: {"status":{"card-play":"OK","req_body":"{\"uri\":\"https://yoto.io/7JtVV\",\"secondsIn\":0,\"cutOff\":0,\"chapterKey\":\"01\",\"trackKey\":\"01\",\"requestId\":\"5385910e-f853-4f34-99a4-d2ed94f02f6d\"}"}}
 
-    def _publish_command(self, topic, payload):
-        self.client.publish(topic, payload)
+    # restart the player
+    def restart(self, deviceId):
+        topic = f"device/{deviceId}/command/restart"
+        self.client.publish(topic)
+
+     # set the ambient light of the player
+    def ambients(self, deviceId, r: int, g: int, b: int):
+        topic = f"device/{deviceId}/command/ambients"
+        payload = {
+            "r": r,
+            "g": g,
+            "b": b
+        }
+        self.client.publish(topic, str(payload))
 
     def _parse_status_message(self, message, player):
         pass

--- a/yoto_api/YotoManager.py
+++ b/yoto_api/YotoManager.py
@@ -71,7 +71,7 @@ class YotoManager:
             return True
         # Check if valid and correct if not
         if self.token.valid_until <= datetime.datetime.now(pytz.utc):
-            _LOGGER.debug(f"{DOMAIN} - Refresh token expired")
+            _LOGGER.debug(f"{DOMAIN} - access token expired")
             self.token: Token = self.api.refresh_token(self.token)
             return True
         return False


### PR DESCRIPTION
No changes of note, more trying to help out given I work on the API's :) So an introduction and a reference to copy from

- I've dropped username + password from the Token. They should be disposed of rather than retained
  - if you reach out to platform-team@yotoplay.com we can get you your own ClientId
  - username/password authentication we'll eventually want to move away API consumers from. Mainly as the user has no way to revoke the access. And instead use a "on behalf of" model where a refresh token is issued to a requesting app at the user's approval.
- Some general tidy up, f-strings, code reduction etc... although it's been several years since I did any python so take my changes with a pinch of salt and personal preference

- I've added some missing MQTT commands and tried to simplify them as much as possible
- I've included links to our (work in progress) API documentation which may help

*I'm a long-time HA user so will try and help out on that repo at some point
