### PR TITLE
fix: improve MQTT connection resilience

### DIFF
--- a/tests/test_mqtt_resilience.py
+++ b/tests/test_mqtt_resilience.py
@@ -1,0 +1,110 @@
+"""Tests for MQTT connection resilience improvements."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+from yoto_api.YotoMQTTClient import YotoMQTTClient
+from yoto_api.Token import Token
+
+
+class TestMQTTClientInit(unittest.TestCase):
+    """Test paho-mqtt v1/v2 compatibility in connect_mqtt."""
+
+    def _make_token(self):
+        t = Token()
+        t.access_token = "fake-token"
+        return t
+
+    @patch("yoto_api.YotoMQTTClient.mqtt")
+    def test_connect_uses_callback_api_version_when_available(self, mock_mqtt):
+        """paho-mqtt 2.x path: CallbackAPIVersion.VERSION1 is passed."""
+        mock_mqtt.CallbackAPIVersion.VERSION1 = "VERSION1"
+        mock_client = MagicMock()
+        mock_mqtt.Client.return_value = mock_client
+
+        client = YotoMQTTClient()
+        client.connect_mqtt(self._make_token(), {"player-1": MagicMock()}, None)
+
+        args = mock_mqtt.Client.call_args
+        self.assertEqual(args[0][0], "VERSION1")
+
+    @patch("yoto_api.YotoMQTTClient.mqtt")
+    def test_connect_falls_back_when_no_callback_api(self, mock_mqtt):
+        """paho-mqtt 1.x path: no CallbackAPIVersion, falls back gracefully."""
+        del mock_mqtt.CallbackAPIVersion
+        mock_client = MagicMock()
+        mock_mqtt.Client.return_value = mock_client
+
+        client = YotoMQTTClient()
+        client.connect_mqtt(self._make_token(), {"player-1": MagicMock()}, None)
+
+        mock_mqtt.Client.assert_called_once()
+
+    @patch("yoto_api.YotoMQTTClient.mqtt")
+    def test_connect_sets_keepalive(self, mock_mqtt):
+        """Explicit keepalive=60 is passed to connect()."""
+        mock_client = MagicMock()
+        mock_mqtt.Client.return_value = mock_client
+
+        client = YotoMQTTClient()
+        client.connect_mqtt(self._make_token(), {"player-1": MagicMock()}, None)
+
+        mock_client.connect.assert_called_once_with(
+            host=client.MQTT_URL, port=443, keepalive=60
+        )
+
+    @patch("yoto_api.YotoMQTTClient.mqtt")
+    def test_connect_registers_on_subscribe(self, mock_mqtt):
+        """on_subscribe callback is registered."""
+        mock_client = MagicMock()
+        mock_mqtt.Client.return_value = mock_client
+
+        client = YotoMQTTClient()
+        client.connect_mqtt(self._make_token(), {"player-1": MagicMock()}, None)
+
+        self.assertEqual(mock_client.on_subscribe, client._on_subscribe)
+
+
+class TestOnDisconnect(unittest.TestCase):
+    """Test improved disconnect logging."""
+
+    def test_clean_disconnect_logs_debug_only(self):
+        """rc=0 (clean disconnect) should not warn."""
+        client = YotoMQTTClient()
+        mock_mqtt_client = MagicMock()
+        mock_mqtt_client._client_id = b"YOTOAPI123"
+
+        with patch("yoto_api.YotoMQTTClient._LOGGER") as mock_logger:
+            client._on_disconnect(mock_mqtt_client, None, 0)
+            mock_logger.debug.assert_called_once()
+            mock_logger.warning.assert_not_called()
+
+    def test_unexpected_disconnect_logs_warning(self):
+        """rc!=0 (unexpected) should warn."""
+        client = YotoMQTTClient()
+        mock_mqtt_client = MagicMock()
+        mock_mqtt_client._client_id = b"YOTOAPI123"
+
+        with patch("yoto_api.YotoMQTTClient._LOGGER") as mock_logger:
+            client._on_disconnect(mock_mqtt_client, None, 7)
+            mock_logger.debug.assert_called_once()
+            mock_logger.warning.assert_called_once()
+
+
+class TestOnConnect(unittest.TestCase):
+    """Test that _on_connect subscribes and requests status."""
+
+    def test_subscribes_to_all_topics_per_player(self):
+        """Each player gets 3 subscriptions + status request."""
+        client = YotoMQTTClient()
+        client.client = MagicMock()
+        players = {"device-abc": MagicMock(), "device-xyz": MagicMock()}
+        userdata = (players, None)
+
+        client._on_connect(client.client, userdata, {}, 0)
+
+        self.assertEqual(client.client.subscribe.call_count, 6)
+        self.assertEqual(client.client.publish.call_count, 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yoto_api/YotoMQTTClient.py
+++ b/yoto_api/YotoMQTTClient.py
@@ -66,10 +66,14 @@ class YotoMQTTClient:
 
             self.update_status(player)
 
-    def _on_subscribe(self, client, userdata, mid, granted_qos, properties=None) -> None:
+    def _on_subscribe(
+        self, client, userdata, mid, granted_qos, properties=None
+    ) -> None:
         _LOGGER.debug(f"{DOMAIN} - MQTT Subscribed: {mid} {granted_qos}")
 
-    def _on_disconnect(self, client: mqtt.Client, userdata, rc, properties=None) -> None:
+    def _on_disconnect(
+        self, client: mqtt.Client, userdata, rc, properties=None
+    ) -> None:
         _LOGGER.debug(f"{DOMAIN} - {client._client_id} - MQTT Disconnected: {rc}")
         if rc != 0:
             _LOGGER.warning(

--- a/yoto_api/YotoMQTTClient.py
+++ b/yoto_api/YotoMQTTClient.py
@@ -24,13 +24,22 @@ class YotoMQTTClient:
         self.client: mqtt.Client = None
 
     def connect_mqtt(self, token: Token, players: dict[YotoPlayer], callback) -> None:
-        #             mqtt.CallbackAPIVersion.VERSION1,
         userdata = (players, callback)
-        self.client = mqtt.Client(
-            client_id="YOTOAPI" + next(iter(players)).replace("-", ""),
-            transport="websockets",
-            userdata=userdata,
-        )
+        try:
+            # paho-mqtt 2.x
+            self.client = mqtt.Client(
+                mqtt.CallbackAPIVersion.VERSION1,
+                client_id="YOTOAPI" + next(iter(players)).replace("-", ""),
+                transport="websockets",
+                userdata=userdata,
+            )
+        except AttributeError:
+            # paho-mqtt 1.x
+            self.client = mqtt.Client(
+                client_id="YOTOAPI" + next(iter(players)).replace("-", ""),
+                transport="websockets",
+                userdata=userdata,
+            )
         self.client.username_pw_set(
             username="_?x-amz-customauthorizer-name=" + self.MQTT_AUTH_NAME,
             password=token.access_token,
@@ -38,8 +47,9 @@ class YotoMQTTClient:
         self.client.on_message = self._on_message
         self.client.on_connect = self._on_connect
         self.client.on_disconnect = self._on_disconnect
+        self.client.on_subscribe = self._on_subscribe
         self.client.tls_set()
-        self.client.connect(host=self.MQTT_URL, port=443)
+        self.client.connect(host=self.MQTT_URL, port=443, keepalive=60)
         self.client.loop_start()
 
     def disconnect_mqtt(self):
@@ -56,8 +66,15 @@ class YotoMQTTClient:
 
             self.update_status(player)
 
-    def _on_disconnect(self, client: mqtt.Client, userdata, rc) -> None:
+    def _on_subscribe(self, client, userdata, mid, granted_qos, properties=None) -> None:
+        _LOGGER.debug(f"{DOMAIN} - MQTT Subscribed: {mid} {granted_qos}")
+
+    def _on_disconnect(self, client: mqtt.Client, userdata, rc, properties=None) -> None:
         _LOGGER.debug(f"{DOMAIN} - {client._client_id} - MQTT Disconnected: {rc}")
+        if rc != 0:
+            _LOGGER.warning(
+                f"{DOMAIN} - Unexpected MQTT disconnection: {rc}. Paho will attempt to reconnect."
+            )
 
     def update_status(self, deviceId: str):
         self.client.publish(f"device/{deviceId}/command/events/request")


### PR DESCRIPTION
## What this does

Hardens the MQTT client against silent failures and improves observability for debugging connection issues.

- **paho-mqtt v1/v2 support** — the commented-out `CallbackAPIVersion.VERSION1` was never wired up, which means environments running paho-mqtt 2.x could hit silent callback failures. This adds a try/except so both versions work.
- **Explicit keepalive** — sets `keepalive=60` on the broker connection instead of relying on defaults.
- **Subscription logging** — adds an `on_subscribe` callback so you can actually see if subscriptions succeed or silently fail.
- **Disconnect warnings** — unexpected disconnects (`rc != 0`) now log at warning level instead of just debug, making them visible without enabling full debug logging.

## Why

I've been looking at #149 (state stops updating after ~20min idle) and while digging through the MQTT client code noticed these gaps. This PR doesn't fix #149 directly — that likely needs a periodic status refresh on the HA coordinator side — but these changes make the connection more resilient and much easier to debug when things go wrong.

## Tests

Added unit tests covering all four changes (7 tests, all passing). No hardware or credentials needed to run them.

```
tests/test_mqtt_resilience.py::TestMQTTClientInit::test_connect_falls_back_when_no_callback_api PASSED
tests/test_mqtt_resilience.py::TestMQTTClientInit::test_connect_registers_on_subscribe PASSED
tests/test_mqtt_resilience.py::TestMQTTClientInit::test_connect_sets_keepalive PASSED
tests/test_mqtt_resilience.py::TestMQTTClientInit::test_connect_uses_callback_api_version_when_available PASSED
tests/test_mqtt_resilience.py::TestOnDisconnect::test_clean_disconnect_logs_debug_only PASSED
tests/test_mqtt_resilience.py::TestOnDisconnect::test_unexpected_disconnect_logs_warning PASSED
tests/test_mqtt_resilience.py::TestOnConnect::test_subscribes_to_all_topics_per_player PASSED
```