### PR TITLE
fix: fix oscillating player.volume from data/status MQTT messages

### DIFF
--- a/yoto_api/YotoMQTTClient.py
+++ b/yoto_api/YotoMQTTClient.py
@@ -22,6 +22,7 @@ class YotoMQTTClient:
         self.MQTT_AUTH_NAME: str = "PublicJWTAuthorizer"
         self.MQTT_URL: str = "aqrphjqbp3u2z-ats.iot.eu-west-2.amazonaws.com"
         self.client: mqtt.Client = None
+        self._players: dict[str, YotoPlayer] = {}
 
     def connect_mqtt(self, token: Token, players: dict[YotoPlayer], callback) -> None:
         #             mqtt.CallbackAPIVersion.VERSION1,
@@ -48,6 +49,7 @@ class YotoMQTTClient:
 
     def _on_connect(self, client, userdata, flags, rc) -> None:
         players = userdata[0]
+        self._players = players
         for player in players:
             self.client.subscribe("device/" + player + "/data/events")
             self.client.subscribe("device/" + player + "/data/status")
@@ -64,6 +66,10 @@ class YotoMQTTClient:
         self.client.publish(f"device/{deviceId}/command/status/request")
 
     def set_volume(self, deviceId: str, volume: int) -> None:
+        player = self._players.get(deviceId)
+        if player is not None and player.volume_max is not None:
+            max_pct = round(player.volume_max / 16 * 100)
+            volume = min(volume, max_pct)
         closest_volume = take_closest(VOLUME_MAPPING_INVERTED, volume)
         topic = f"device/{deviceId}/command/volume/set"
         payload = json.dumps({"volume": closest_volume})

--- a/yoto_api/YotoMQTTClient.py
+++ b/yoto_api/YotoMQTTClient.py
@@ -171,9 +171,9 @@ class YotoMQTTClient:
             player.active_card = active_card
             player.card_id = active_card
 
-        status_volume = get_child_value(status, "volume")
-        if status_volume is not None:
-            player.volume = status_volume
+        system_volume = get_child_value(status, "volume")
+        if system_volume is not None:
+            player.system_volume = system_volume
 
         user_volume = get_child_value(status, "userVolume")
         if user_volume is not None:


### PR DESCRIPTION
`_parse_status_message` and `_parse_events_message` were both writing to `player.volume` from MQTT fields that share a name but use different scales:

- `data/events.volume` is a 0..`volumeMax` step value (0-16, clamped by the day/night limiter).
- `data/status.volume` is a 0-100 percentage, the same value the REST API reports as `systemVolumePercentage`.

When both topics fired, `player.volume` flipped between scales, breaking downstream volume consumers.

Route `data/status.volume` to `player.system_volume`, mirroring the existing `userVolume` mapping and the REST parser. `player.volume` is now sourced exclusively from `data/events`.

| MQTT field | REST field | Player attribute | Scale |
|---|---|---|---|
| `data/status.userVolume` | `userVolumePercentage` | `user_volume` | 0-100 |
| `data/status.volume` | `systemVolumePercentage` | `system_volume` | 0-100 |
| `data/events.volume` | - | `volume` | 0..`volume_max` |
