### PR TITLE
fix: fix client_id collision when running multiple consumers on the same account

### DIFF
--- a/yoto_api/YotoMQTTClient.py
+++ b/yoto_api/YotoMQTTClient.py
@@ -5,6 +5,7 @@ import paho.mqtt.client as mqtt
 import json
 import datetime
 import pytz
+import uuid
 
 from yoto_api.YotoPlayer import YotoPlayer
 
@@ -27,7 +28,7 @@ class YotoMQTTClient:
         #             mqtt.CallbackAPIVersion.VERSION1,
         userdata = (players, callback)
         self.client = mqtt.Client(
-            client_id="YOTOAPI" + next(iter(players)).replace("-", ""),
+            client_id=f"YOTOAPI-{uuid.uuid4().hex}",
             transport="websockets",
             userdata=userdata,
         )


### PR DESCRIPTION
The MQTT `client_id` was derived from the first deviceId in the `players` dict:

    client_id="YOTOAPI" + next(iter(players)).replace("-", "")

Two consumers connecting to the same Yoto account (e.g. two Home Assistant instances) generate the exact same `client_id`. AWS IoT enforces uniqueness, so each connection kicks the other off in a tight reconnect loop, with each side getting roughly 1 second of usable connection. Symptoms include random `set_volume` failures and stale state.

Generate a fresh UUID per `YotoMQTTClient` instance instead:

    client_id=f"YOTOAPI-{uuid.uuid4().hex}"

The id is stable for the lifetime of one instance (so reconnects keep the same session) and unique across processes. No persistence needed: Yoto uses `clean_session=True`, so there's no broker-side state to preserve across restarts.
