### PR TITLE
fix: remove dash from MQTT client_id

### DIFF
--- a/yoto_api/YotoMQTTClient.py
+++ b/yoto_api/YotoMQTTClient.py
@@ -29,7 +29,7 @@ class YotoMQTTClient:
         #             mqtt.CallbackAPIVersion.VERSION1,
         userdata = (players, callback)
         self.client = mqtt.Client(
-            client_id=f"YOTOAPI-{uuid.uuid4().hex}",
+            client_id=f"YOTOAPI{uuid.uuid4().hex}",
             transport="websockets",
             userdata=userdata,
         )


### PR DESCRIPTION
Followup to #173 🙈. The Yoto MQTT custom authorizer rejects connections whose `client_id` contains a `-`, causing a continuous disconnect 7 reconnect loop. Drop the dash separator between the prefix and the UUID.

I tested that one with my Yoto Mini et it works.