### PR TITLE
feat: add seek, next_track, and previous_track

### DIFF
--- a/yoto_api/YotoAPI.py
+++ b/yoto_api/YotoAPI.py
@@ -13,7 +13,7 @@ from .Token import Token
 from .Card import Card, Chapter, Track
 from .Family import Family
 from .YotoPlayer import YotoPlayer, YotoPlayerConfig, Alarm
-from .utils import get_child_value
+from .utils import get_child_value, get_raw_value
 from .exceptions import AuthenticationError
 
 
@@ -239,22 +239,18 @@ class YotoAPI:
             # _LOGGER.debug(f"{DOMAIN} - Updating Details:  {item}")
             if card.chapters is None:
                 card.chapters = {}
-            if get_child_value(item, "key") not in card.chapters:
-                chapter: Chapter = Chapter(
-                    key=get_child_value(item, "key"),
-                )
-                card.chapters[chapter.key] = chapter
-            key = get_child_value(item, "key")
+            key = get_raw_value(item, "key")
+            if key not in card.chapters:
+                card.chapters[key] = Chapter(key=key)
             card.chapters[key].icon = get_child_value(item, "display.icon16x16")
             card.chapters[key].title = get_child_value(item, "title")
             card.chapters[key].duration = get_child_value(item, "duration")
             for track_item in item["tracks"]:
                 if card.chapters[key].tracks is None:
                     card.chapters[key].tracks = {}
-                if get_child_value(track_item, "key") not in card.chapters[key].tracks:
-                    track: Track = Track(
-                        key=get_child_value(track_item, "key"),
-                    )
+                track_key = get_raw_value(track_item, "key")
+                if track_key not in card.chapters[key].tracks:
+                    track: Track = Track(key=track_key)
                     # _LOGGER.debug(f"{DOMAIN} - track details:  {track_item}")
                     card.chapters[key].tracks[track.key] = track
                     card.chapters[key].tracks[track.key].icon = get_child_value(

--- a/yoto_api/YotoMQTTClient.py
+++ b/yoto_api/YotoMQTTClient.py
@@ -233,9 +233,7 @@ class YotoMQTTClient:
         if player.card_id == "none":
             player.card_id = None
         player.track_key = get_raw_value(message, "trackKey") or player.track_key
-        player.chapter_key = (
-            get_raw_value(message, "chapterKey") or player.chapter_key
-        )
+        player.chapter_key = get_raw_value(message, "chapterKey") or player.chapter_key
         player.last_updated_at = datetime.datetime.now(pytz.utc)
 
     # {"trackLength":315,"position":0,"cardId":"7JtVV","repeatAll":true,"source":"remote","cardUpdatedAt":"2021-07-13T14:51:26.576Z","chapterTitle":"Snow and Tell","chapterKey":"03","trackTitle":"Snow and Tell","trackKey":"03","streaming":false,"volume":5,"volumeMax":8,"playbackStatus":"playing","playbackWait":false,"sleepTimerActive":false,"eventUtc":1715133271}

--- a/yoto_api/YotoMQTTClient.py
+++ b/yoto_api/YotoMQTTClient.py
@@ -12,7 +12,7 @@ from yoto_api.YotoPlayer import YotoPlayer
 
 from .const import DOMAIN, VOLUME_MAPPING_INVERTED
 from .Token import Token
-from .utils import get_child_value, take_closest
+from .utils import get_child_value, get_raw_value, take_closest
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -232,9 +232,9 @@ class YotoMQTTClient:
         player.card_id = get_child_value(message, "cardId") or player.card_id
         if player.card_id == "none":
             player.card_id = None
-        player.track_key = get_child_value(message, "trackKey") or player.track_key
+        player.track_key = get_raw_value(message, "trackKey") or player.track_key
         player.chapter_key = (
-            get_child_value(message, "chapterKey") or player.chapter_key
+            get_raw_value(message, "chapterKey") or player.chapter_key
         )
         player.last_updated_at = datetime.datetime.now(pytz.utc)
 

--- a/yoto_api/YotoManager.py
+++ b/yoto_api/YotoManager.py
@@ -15,6 +15,16 @@ from .Card import Card
 _LOGGER = logging.getLogger(__name__)
 
 
+def _format_key(value) -> str:
+    """Zero-pad numeric chapter/track keys to 2 digits (e.g. 1 -> "01", "9" -> "09")."""
+    if value is None:
+        return None
+    s = str(value)
+    if s.isdigit() and len(s) < 2:
+        return s.zfill(2)
+    return s
+
+
 class YotoManager:
     def __init__(self, client_id: str) -> None:
         if not client_id:
@@ -102,6 +112,55 @@ class YotoManager:
             cutoff=cutoff,
             chapterKey=chapterKey,
             trackKey=trackKey,
+        )
+
+    def seek(self, player_id: str, position: int) -> None:
+        player = self.players.get(player_id)
+        if player is None or player.card_id is None:
+            return
+        self.play_card(
+            player_id=player_id,
+            card=player.card_id,
+            secondsIn=position,
+            chapterKey=_format_key(player.chapter_key),
+            trackKey=_format_key(player.track_key),
+        )
+
+    def next_track(self, player_id: str) -> None:
+        self._skip_track(player_id, direction=1)
+
+    def previous_track(self, player_id: str) -> None:
+        self._skip_track(player_id, direction=-1)
+
+    def _skip_track(self, player_id: str, direction: int) -> None:
+        player = self.players.get(player_id)
+        if player is None or player.card_id is None:
+            return
+        if player.card_id not in self.library or not self.library[player.card_id].chapters:
+            self.update_card_detail(player.card_id)
+        card = self.library.get(player.card_id)
+        if card is None or not card.chapters:
+            return
+
+        playlist = [
+            (chapter_key, track_key)
+            for chapter_key, chapter in card.chapters.items()
+            for track_key in (chapter.tracks or {})
+        ]
+        current = (player.chapter_key, player.track_key)
+        if current not in playlist:
+            return
+
+        new_idx = playlist.index(current) + direction
+        if not 0 <= new_idx < len(playlist):
+            return
+
+        new_chapter_key, new_track_key = playlist[new_idx]
+        self.play_card(
+            player_id=player_id,
+            card=player.card_id,
+            chapterKey=_format_key(new_chapter_key),
+            trackKey=_format_key(new_track_key),
         )
 
     def set_volume(self, player_id: str, volume: int) -> None:

--- a/yoto_api/YotoManager.py
+++ b/yoto_api/YotoManager.py
@@ -15,16 +15,6 @@ from .Card import Card
 _LOGGER = logging.getLogger(__name__)
 
 
-def _format_key(value) -> str:
-    """Zero-pad numeric chapter/track keys to 2 digits (e.g. 1 -> "01", "9" -> "09")."""
-    if value is None:
-        return None
-    s = str(value)
-    if s.isdigit() and len(s) < 2:
-        return s.zfill(2)
-    return s
-
-
 class YotoManager:
     def __init__(self, client_id: str) -> None:
         if not client_id:
@@ -122,8 +112,8 @@ class YotoManager:
             player_id=player_id,
             card=player.card_id,
             secondsIn=position,
-            chapterKey=_format_key(player.chapter_key),
-            trackKey=_format_key(player.track_key),
+            chapterKey=player.chapter_key,
+            trackKey=player.track_key,
         )
 
     def next_track(self, player_id: str) -> None:
@@ -159,8 +149,8 @@ class YotoManager:
         self.play_card(
             player_id=player_id,
             card=player.card_id,
-            chapterKey=_format_key(new_chapter_key),
-            trackKey=_format_key(new_track_key),
+            chapterKey=new_chapter_key,
+            trackKey=new_track_key,
         )
 
     def set_volume(self, player_id: str, volume: int) -> None:

--- a/yoto_api/YotoManager.py
+++ b/yoto_api/YotoManager.py
@@ -126,7 +126,10 @@ class YotoManager:
         player = self.players.get(player_id)
         if player is None or player.card_id is None:
             return
-        if player.card_id not in self.library or not self.library[player.card_id].chapters:
+        if (
+            player.card_id not in self.library
+            or not self.library[player.card_id].chapters
+        ):
             self.update_card_detail(player.card_id)
         card = self.library.get(player.card_id)
         if card is None or not card.chapters:

--- a/yoto_api/utils.py
+++ b/yoto_api/utils.py
@@ -7,6 +7,27 @@ from typing import Any
 
 
 def get_child_value(data: Any, key: str) -> Any:
+    """
+    Look up `key` in a nested dict/list. Dotted keys descend into children.
+
+    String values that look like numbers or booleans are coerced
+    (e.g. "16" -> 16, "true" -> True). Use `get_raw_value` for ID-shaped
+    fields like chapter or track keys where leading-zero formatting matters.
+    """
+    value = get_raw_value(data, key)
+    if isinstance(value, str):
+        lower = value.lower()
+        if lower == "true":
+            return True
+        if lower == "false":
+            return False
+        if lower.lstrip("+-").isdigit():
+            return int(value)
+    return value
+
+
+def get_raw_value(data: Any, key: str) -> Any:
+    """Like `get_child_value` but returns the raw value with no type coercion."""
     value: Any = data
     for x in key.split("."):
         try:
@@ -19,18 +40,7 @@ def get_child_value(data: Any, key: str) -> Any:
             value = value[int(x)]
             continue
         except Exception:
-            value = None
-            break
-
-    if isinstance(value, str):
-        lower = value.lower()
-        if lower == "true":
-            return True
-        if lower == "false":
-            return False
-        if lower.lstrip("+-").isdigit():
-            return int(value)
-
+            return None
     return value
 
 


### PR DESCRIPTION
Adds three media controls to `YotoManager` so consumers (HA integration, etc.) can drive playback without re-publishing a full `card_play` command themselves:

- `seek(player_id, position)`: jump to a position in the current track.
- `next_track(player_id)`: skip to the next track. Crosses chapter boundaries automatically. Stops at the end of the card.
- `previous_track(player_id)`: same, in the other direction. Stops at the start of the card.

Card chapter data is fetched on demand if it hasn't been loaded yet, so callers don't need to pre-fetch.

This simplifies the HA integration: the next, previous, and seek service handlers can call these directly instead of duplicating chapter and track lookup logic on the integration side.

### Note on chapter / track keys

The Yoto firmware rejects `card-play` if a chapter or track key is sent without its leading zero (e.g. `"8"` instead of `"08"`). PR #170 made `get_child_value` auto-convert any pure-digit string to an int, which strips that padding when chapter and track keys are parsed.

To preserve formatting, this PR adds `get_raw_value` alongside `get_child_value` in `utils.py`.
