### PR TITLE
feat: prepare library for Home Assistant core integration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,33 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:yoto.dev)",
+      "WebFetch(domain:yoto.space)",
+      "Bash(grep -n -E 'online|offline|presence|heartbeat|lifecycle|last.will|will.*topic|lwt|alive|stale|\\\\$aws' /tmp/homebridge-yoto/lib/platform.js /tmp/homebridge-yoto/NOTES.md /tmp/homebridge-yoto/PLAN.md)",
+      "Bash(rm -rf yoto-nodejs-client)",
+      "Bash(npm pack *)",
+      "Bash(tar xzf *)",
+      "Bash(python -m pytest tests/ -x)",
+      "Bash(python3 -m pytest tests/)",
+      "Bash(python3 -c \"from yoto_api.YotoMQTTClient import YotoMQTTClient; c = YotoMQTTClient\\(\\); print\\('ok'\\)\")",
+      "Bash(pip3 install *)",
+      "Bash(python3 -c \"from yoto_api.YotoMQTTClient import YotoMQTTClient; c = YotoMQTTClient\\(\\); print\\('import ok'\\)\")",
+      "Bash(python3 -m venv yoto-venv)",
+      "Bash(/tmp/yoto-venv/bin/pip install *)",
+      "Bash(/tmp/yoto-venv/bin/python -c \"from yoto_api.YotoMQTTClient import YotoMQTTClient; c = YotoMQTTClient\\(\\); print\\('import ok'\\)\")",
+      "Bash(git -C /Users/piitaya/Code/piitaya/yoto_api diff --stat)",
+      "Bash(git -C /Users/piitaya/Code/piitaya/yoto_api diff)",
+      "Bash(grep -n \"^\\\\.env\\\\|env$\" /Users/piitaya/Code/piitaya/yoto_api/.gitignore)",
+      "Bash(git -C /Users/piitaya/Code/piitaya/yoto_api status)",
+      "Bash(git -C /Users/piitaya/Code/piitaya/yoto_api diff HEAD)",
+      "Bash(python3 -c \"from dotenv import set_key; help\\(set_key\\)\")",
+      "Bash(PYTHONPATH=/Users/piitaya/Code/piitaya/yoto_api /tmp/yoto-venv/bin/python -m pytest tests/ -v)",
+      "Bash(.venv/bin/pytest --cov=yoto_api --cov-report=term-missing)",
+      "Bash(.venv/bin/pytest --cov=yoto_api --cov-report=term)",
+      "Bash(.venv/bin/ruff check *)",
+      "Bash(.venv/bin/mypy)",
+      "Bash(.venv/bin/pytest --cov=yoto_api --cov-report=term -q)",
+      "Bash(.venv/bin/python -c \"import yoto_api; print\\(yoto_api.YotoManager.__init__.__annotations__\\); print\\('ok'\\)\")"
+    ]
+  }
+}

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/cdnninja/yoto_api",
-    version="2.3.0",
+    version="2.4.0",
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/cdnninja/yoto_api",
-    version="2.4.0",
+    version="2.3.0",
     zip_safe=False,
 )

--- a/yoto_api/YotoAPI.py
+++ b/yoto_api/YotoAPI.py
@@ -81,8 +81,9 @@ class YotoAPI:
             raise YotoAPIError(f"Get family response malformed: {err}") from err
 
     def update_player_list(self, token: Token, players: dict) -> None:
-        # Skips /status and /config so callers without the
-        # `family:device-status:view` scope can use it.
+        # Lighter than update_players: only /devices/mine + /config (no
+        # /status, which needs `family:device-status:view`). Populates
+        # device metadata + mac + firmware. Live state is left to MQTT.
         response = self._get_devices(token)
         for item in response["devices"]:
             deviceId = get_child_value(item, "deviceId")
@@ -97,6 +98,12 @@ class YotoAPI:
             players[deviceId].form_factor = get_child_value(item, "formFactor")
             players[deviceId].release_channel = get_child_value(item, "releaseChannel")
             players[deviceId].online = get_child_value(item, "online")
+
+            config = self._get_device_config(token, deviceId)
+            players[deviceId].mac = get_child_value(config, "device.mac")
+            players[deviceId].firmware_version = get_child_value(
+                config, "device.releaseChannelVersion"
+            )
 
     def update_players(self, token: Token, players: list[YotoPlayer]) -> None:
         response = self._get_devices(token)

--- a/yoto_api/YotoAPI.py
+++ b/yoto_api/YotoAPI.py
@@ -5,6 +5,7 @@ import logging
 import datetime
 import json
 import time
+from typing import Optional
 
 from datetime import timedelta
 import pytz
@@ -14,20 +15,32 @@ from .Card import Card, Chapter, Track
 from .Family import Family
 from .YotoPlayer import YotoPlayer, YotoPlayerConfig, Alarm
 from .utils import get_child_value, get_raw_value
-from .exceptions import AuthenticationError
+from .exceptions import AuthenticationError, YotoAPIError, YotoError
 
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class YotoAPI:
-    def __init__(self, client_id) -> None:
+    def __init__(self, client_id: Optional[str] = None) -> None:
         self.BASE_URL: str = "https://api.yotoplay.com"
         self.AUTH_URL: str = "https://login.yotoplay.com/oauth/device/code"
         self.TOKEN_URL: str = "https://login.yotoplay.com/oauth/token"
-        self.CLIENT_ID: str = client_id
+        self.CLIENT_ID: Optional[str] = client_id
+
+    def _request_json(self, method: str, url: str, what: str, **kwargs) -> dict:
+        try:
+            response = requests.request(method, url, **kwargs)
+            return response.json()
+        except (requests.RequestException, ValueError) as err:
+            raise YotoAPIError(f"{what} failed: {err}") from err
+
+    def _require_client_id(self, operation: str) -> None:
+        if self.CLIENT_ID is None:
+            raise YotoError(f"client_id required for {operation}")
 
     def refresh_token(self, token: Token) -> Token:
+        self._require_client_id("refresh_token")
         data = {
             "client_id": self.CLIENT_ID,
             "grant_type": "refresh_token",
@@ -36,29 +49,54 @@ class YotoAPI:
         }
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
 
-        response = requests.post(self.TOKEN_URL, data=data, headers=headers).json()
+        response = self._request_json(
+            "POST", self.TOKEN_URL, "Refresh token", data=data, headers=headers
+        )
         _LOGGER.debug(f"{DOMAIN} - Refresh Token Response {response}")
         if response.get("error"):
             raise AuthenticationError("Refresh token invalid")
-        valid_until = datetime.datetime.now(pytz.utc) + timedelta(
-            seconds=response["expires_in"]
-        )
-
-        return Token(
-            access_token=response["access_token"],
-            refresh_token=response["refresh_token"],
-            token_type=response["token_type"],
-            scope=token.scope,
-            valid_until=valid_until,
-        )
+        try:
+            valid_until = datetime.datetime.now(pytz.utc) + timedelta(
+                seconds=response["expires_in"]
+            )
+            return Token(
+                access_token=response["access_token"],
+                refresh_token=response["refresh_token"],
+                token_type=response["token_type"],
+                scope=token.scope,
+                valid_until=valid_until,
+            )
+        except (KeyError, TypeError) as err:
+            raise YotoAPIError(f"Refresh token response malformed: {err}") from err
 
     def get_family(self, token: Token) -> dict:
         url = self.BASE_URL + "/user/family"
         headers = self._get_authenticated_headers(token)
-        response = requests.get(url, headers=headers).json()
+        response = self._request_json("GET", url, "Get family", headers=headers)
 
         _LOGGER.debug(f"{DOMAIN} - Get Family Response: {response}")
-        return Family(response["family"])
+        try:
+            return Family(response["family"])
+        except (KeyError, TypeError, ValueError) as err:
+            raise YotoAPIError(f"Get family response malformed: {err}") from err
+
+    def update_player_list(self, token: Token, players: dict) -> None:
+        # Skips /status and /config so callers without the
+        # `family:device-status:view` scope can use it.
+        response = self._get_devices(token)
+        for item in response["devices"]:
+            deviceId = get_child_value(item, "deviceId")
+            if deviceId not in players:
+                players[deviceId] = YotoPlayer(id=deviceId)
+            players[deviceId].name = get_child_value(item, "name")
+            players[deviceId].description = get_child_value(item, "description")
+            players[deviceId].device_type = get_child_value(item, "deviceType")
+            players[deviceId].device_family = get_child_value(item, "deviceFamily")
+            players[deviceId].device_group = get_child_value(item, "deviceGroup")
+            players[deviceId].generation = get_child_value(item, "generation")
+            players[deviceId].form_factor = get_child_value(item, "formFactor")
+            players[deviceId].release_channel = get_child_value(item, "releaseChannel")
+            players[deviceId].online = get_child_value(item, "online")
 
     def update_players(self, token: Token, players: list[YotoPlayer]) -> None:
         response = self._get_devices(token)
@@ -70,7 +108,13 @@ class YotoAPI:
                 players[player.id] = player
             deviceId = get_child_value(item, "deviceId")
             players[deviceId].name = get_child_value(item, "name")
+            players[deviceId].description = get_child_value(item, "description")
             players[deviceId].device_type = get_child_value(item, "deviceType")
+            players[deviceId].device_family = get_child_value(item, "deviceFamily")
+            players[deviceId].device_group = get_child_value(item, "deviceGroup")
+            players[deviceId].generation = get_child_value(item, "generation")
+            players[deviceId].form_factor = get_child_value(item, "formFactor")
+            players[deviceId].release_channel = get_child_value(item, "releaseChannel")
             players[deviceId].online = get_child_value(item, "online")
 
             # Should we call here or make this a separate call from YM?  This could help us reduce API calls.
@@ -316,13 +360,16 @@ class YotoAPI:
             config_payload["alarms"] = alarm_payload
         data = {"deviceId": player_id, "config": config_payload}
         headers = self._get_authenticated_headers(token)
-        response = requests.put(url, headers=headers, data=json.dumps(data)).json()
+        response = self._request_json(
+            "PUT", url, "Set device config", headers=headers, data=json.dumps(data)
+        )
         _LOGGER.debug(f"{DOMAIN} - Set Device Config Payload: {data}")
         _LOGGER.debug(f"{DOMAIN} - Set Device Config Response: {response}")
         return response
 
     def get_authorization(self) -> dict:
         """Get authorization code and user instructions."""
+        self._require_client_id("device code authorization")
         data = {
             "audience": self.BASE_URL,
             "client_id": self.CLIENT_ID,
@@ -330,15 +377,22 @@ class YotoAPI:
         }
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
 
-        response = requests.post(self.AUTH_URL, data=data, headers=headers)
+        try:
+            response = requests.post(self.AUTH_URL, data=data, headers=headers)
+        except requests.RequestException as err:
+            raise YotoAPIError(f"Authorization request failed: {err}") from err
         if not response.ok:
             raise AuthenticationError(
                 f"Authorization failed: {response.status_code} {response.text}"
             )
 
-        return response.json()
+        try:
+            return response.json()
+        except ValueError as err:
+            raise YotoAPIError(f"Authorization response malformed: {err}") from err
 
     def poll_for_token(self, auth_result: dict) -> Token:
+        self._require_client_id("device code token polling")
         code = auth_result["device_code"]
         interval = auth_result.get("interval", 5)
         expires_in = auth_result.get("expires_in", 300)
@@ -359,8 +413,13 @@ class YotoAPI:
             }
             headers = {"Content-Type": "application/x-www-form-urlencoded"}
 
-            response = requests.post(self.TOKEN_URL, data=token_data, headers=headers)
-            response_body = response.json()
+            try:
+                response = requests.post(
+                    self.TOKEN_URL, data=token_data, headers=headers
+                )
+                response_body = response.json()
+            except (requests.RequestException, ValueError) as err:
+                raise YotoAPIError(f"Token poll request failed: {err}") from err
 
             # Successful authentication
             if response.ok:
@@ -417,7 +476,7 @@ class YotoAPI:
 
         headers = self._get_authenticated_headers(token)
 
-        response = requests.get(url, headers=headers).json()
+        response = self._request_json("GET", url, "Get devices", headers=headers)
         _LOGGER.debug(f"{DOMAIN} - Get Devices Response: {response}")
         return response
 
@@ -426,7 +485,9 @@ class YotoAPI:
 
         headers = self._get_authenticated_headers(token)
 
-        response = requests.get(url, headers=headers).json()
+        response = self._request_json(
+            "GET", url, f"Get device {player_id} status", headers=headers
+        )
         _LOGGER.debug(f"{DOMAIN} - Get Device {player_id} Status Response: {response}")
         return response
 
@@ -435,7 +496,9 @@ class YotoAPI:
 
         headers = self._get_authenticated_headers(token)
 
-        response = requests.get(url, headers=headers).json()
+        response = self._request_json(
+            "GET", url, f"Get device {player_id} config", headers=headers
+        )
         _LOGGER.debug(f"{DOMAIN} - Get Device {player_id} Config Response: {response}")
         return response
         #  2024-05-15 17:25:48,604 yoto_api.YotoAPI DEBUG:yoto_api - Get Device Config Response: {'device': {'deviceId': 'y23IBS76kCaOSrGlz29XhIFO', 'name': '', 'errorCode': None, 'fwVersion': 'v2.17.5-5', 'popCode': 'FAJKEH', 'releaseChannelId': 'prerelease', 'releaseChannelVersion': 'v2.17.5-5', 'activationPopCode': 'IBSKCAAA', 'registrationCode': 'IBSKCAAA', 'deviceType': 'v3', 'deviceFamily': 'v3', 'deviceGroup': '', 'mac': 'b4:8a:0a:92:7a:f4', 'online': True, 'geoTimezone': 'America/Edmonton', 'getPosix': 'MST7MDT,M3.2.0,M11.1.0', 'status': {'activeCard': 'none', 'aliveTime': None, 'als': 0, 'battery': None, 'batteryLevel': 100, 'batteryRemaining': None, 'bgDownload': 0, 'bluetoothHp': 0, 'buzzErrors': 0, 'bytesPS': 0, 'cardInserted': 0, 'chgStatLevel': None, 'charging': 0, 'day': 1, 'dayBright': None, 'dbatTimeout': None, 'dnowBrightness': None, 'deviceId': 'y23IBS76kCaOSrGlz29XhIFO', 'errorsLogged': 164, 'failData': None, 'failReason': None, 'free': None, 'free32': None, 'freeDisk': 30219824, 'freeDMA': None, 'fwVersion': 'v2.17.5-5', 'headphones': 0, 'lastSeenAt': None, 'missedLogs': None, 'nfcErrs': 'n/a', 'nightBright': None, 'nightlightMode': '0x194a55', 'playingStatus': 0, 'powerCaps': '0x02', 'powerSrc': 2, 'qiOtp': None, 'sd_info': None, 'shutDown': None, 'shutdownTimeout': None, 'ssid': 'speed', 'statusVersion': None, 'temp': '0:24', 'timeFormat': None, 'totalDisk': 31385600, 'twdt': 0, 'updatedAt': '2024-05-15T23:23:45.284Z', 'upTime': 159925, 'userVolume': 31, 'utcOffset': -21600, 'utcTime': 1715815424, 'volume': 34, 'wifiRestarts': None, 'wifiStrength': -54}, 'config': {'locale': 'en', 'bluetoothEnabled': '1', 'repeatAll': True, 'showDiagnostics': True, 'btHeadphonesEnabled': True, 'pauseVolumeDown': False, 'pausePowerButton': True, 'displayDimTimeout': '60', 'shutdownTimeout': '3600', 'headphonesVolumeLimited': False, 'dayTime': '06:30', 'maxVolumeLimit': '16', 'ambientColour': '#40bfd9', 'dayDisplayBrightness': 'auto', 'dayYotoDaily': '3nC80/daily/<yyyymmdd>', 'dayYotoRadio': '3nC80/radio-day/01', 'daySoundsOff': '0', 'nightTime': '18:20', 'nightMaxVolumeLimit': '8', 'nightAmbientColour': '#f57399', 'nightDisplayBrightness': '100', 'nightYotoDaily': '0', 'nightYotoRadio': '0', 'nightSoundsOff': '1', 'hourFormat': '12', 'timezone': '', 'displayDimBrightness': '0', 'systemVolume': '87', 'volumeLevel': 'safe', 'clockFace': 'digital-sun', 'logLevel': 'none', 'alarms': []}, 'shortcuts': {'versionId': '36645a9463e038d6cb9923257b38d9d9df7a6509', 'modes': {'day': {'content': [{'cmd': 'track-play', 'params': {'card': '3nC80', 'chapter': 'daily', 'track': '<yyyymmdd>'}}, {'cmd': 'track-play', 'params': {'card': '3nC80', 'chapter': 'radio-day', 'track': '01'}}]}, 'night': {'content': [{'cmd': 'track-play', 'params': {'card': '3nC80', 'chapter': 'daily', 'track': '<yyyymmdd>'}}, {'cmd': 'track-play', 'params': {'card': '3nC80', 'chapter': 'radio-night', 'track': '01'}}]}}}}}
@@ -445,7 +508,7 @@ class YotoAPI:
         url = self.BASE_URL + "/card/family/library"
         headers = self._get_authenticated_headers(token)
 
-        response = requests.get(url, headers=headers).json()
+        response = self._request_json("GET", url, "Get card library", headers=headers)
         # _LOGGER.debug(f"{DOMAIN} - Get Card Library: {response}")
         return response
 
@@ -578,7 +641,9 @@ class YotoAPI:
         url = self.BASE_URL + "/card/" + cardid
         headers = self._get_authenticated_headers(token)
 
-        response = requests.get(url, headers=headers).json()
+        response = self._request_json(
+            "GET", url, f"Get card {cardid} detail", headers=headers
+        )
         # _LOGGER.debug(f"{DOMAIN} - Get Card Detail: {response}")
         return response
 

--- a/yoto_api/YotoMQTTClient.py
+++ b/yoto_api/YotoMQTTClient.py
@@ -11,6 +11,7 @@ from yoto_api.YotoPlayer import YotoPlayer
 
 
 from .const import DOMAIN, VOLUME_MAPPING_INVERTED
+from .exceptions import YotoMQTTError
 from .Token import Token
 from .utils import get_child_value, get_raw_value, take_closest
 
@@ -28,25 +29,31 @@ class YotoMQTTClient:
     def connect_mqtt(self, token: Token, players: dict[YotoPlayer], callback) -> None:
         #             mqtt.CallbackAPIVersion.VERSION1,
         userdata = (players, callback)
-        self.client = mqtt.Client(
-            client_id=f"YOTOAPI{uuid.uuid4().hex}",
-            transport="websockets",
-            userdata=userdata,
-        )
-        self.client.username_pw_set(
-            username="_?x-amz-customauthorizer-name=" + self.MQTT_AUTH_NAME,
-            password=token.access_token,
-        )
-        self.client.on_message = self._on_message
-        self.client.on_connect = self._on_connect
-        self.client.on_disconnect = self._on_disconnect
-        self.client.tls_set()
-        self.client.connect(host=self.MQTT_URL, port=443)
-        self.client.loop_start()
+        try:
+            self.client = mqtt.Client(
+                client_id=f"YOTOAPI{uuid.uuid4().hex}",
+                transport="websockets",
+                userdata=userdata,
+            )
+            self.client.username_pw_set(
+                username="_?x-amz-customauthorizer-name=" + self.MQTT_AUTH_NAME,
+                password=token.access_token,
+            )
+            self.client.on_message = self._on_message
+            self.client.on_connect = self._on_connect
+            self.client.on_disconnect = self._on_disconnect
+            self.client.tls_set()
+            self.client.connect(host=self.MQTT_URL, port=443)
+            self.client.loop_start()
+        except Exception as err:
+            raise YotoMQTTError(f"MQTT connect failed: {err}") from err
 
     def disconnect_mqtt(self):
-        self.client.loop_stop()
-        self.client.disconnect()
+        try:
+            self.client.loop_stop()
+            self.client.disconnect()
+        except Exception as err:
+            raise YotoMQTTError(f"MQTT disconnect failed: {err}") from err
 
     def _on_connect(self, client, userdata, flags, rc) -> None:
         players = userdata[0]
@@ -62,9 +69,18 @@ class YotoMQTTClient:
     def _on_disconnect(self, client: mqtt.Client, userdata, rc) -> None:
         _LOGGER.debug(f"{DOMAIN} - {client._client_id} - MQTT Disconnected: {rc}")
 
+    def _publish(self, topic: str, payload=None) -> None:
+        try:
+            if payload is None:
+                self.client.publish(topic)
+            else:
+                self.client.publish(topic, payload)
+        except Exception as err:
+            raise YotoMQTTError(f"MQTT publish to {topic} failed: {err}") from err
+
     def update_status(self, deviceId: str):
-        self.client.publish(f"device/{deviceId}/command/events/request")
-        self.client.publish(f"device/{deviceId}/command/status/request")
+        self._publish(f"device/{deviceId}/command/events/request")
+        self._publish(f"device/{deviceId}/command/status/request")
 
     def set_volume(self, deviceId: str, volume: int) -> None:
         player = self._players.get(deviceId)
@@ -74,29 +90,29 @@ class YotoMQTTClient:
         closest_volume = take_closest(VOLUME_MAPPING_INVERTED, volume)
         topic = f"device/{deviceId}/command/volume/set"
         payload = json.dumps({"volume": closest_volume})
-        self.client.publish(topic, str(payload))
+        self._publish(topic, str(payload))
         self.update_status(deviceId)
         # {"status":{"set-volume":"OK","req_body":"{\"volume\":25,\"requestId\":\"39804a13-988d-43d2-b30f-1f3b9b5532f0\"}"}}
 
     def set_sleep(self, deviceId: str, seconds: int) -> None:
         topic = f"device/{deviceId}/command/sleep-timer/set"
         payload = json.dumps({"seconds": seconds})
-        self.client.publish(topic, str(payload))
+        self._publish(topic, str(payload))
         self.update_status(deviceId)
 
     def card_stop(self, deviceId: str) -> None:
         topic = f"device/{deviceId}/command/card/stop"
-        self.client.publish(topic)
+        self._publish(topic)
         self.update_status(deviceId)
 
     def card_pause(self, deviceId: str) -> None:
         topic = f"device/{deviceId}/command/card/pause"
-        self.client.publish(topic)
+        self._publish(topic)
         self.update_status(deviceId)
 
     def card_resume(self, deviceId: str) -> None:
         topic = f"device/{deviceId}/command/card/resume"
-        self.client.publish(topic)
+        self._publish(topic)
         self.update_status(deviceId)
         # MQTT Message: {"status":{"card-pause":"OK","req_body":""}}
 
@@ -123,7 +139,7 @@ class YotoMQTTClient:
             payload["secondsIn"] = int(secondsIn)
         json_payload = json.dumps(payload)
         _LOGGER.debug(f"{DOMAIN} - card-play payload: {json_payload}")
-        self.client.publish(topic, json_payload)
+        self._publish(topic, json_payload)
         self.update_status(deviceId)
         # MQTT Message: {"status":{"card-play":"OK","req_body":"{\"uri\":\"https://yoto.io/7JtVV\",\"secondsIn\":0,\"cutOff\":0,\"chapterKey\":\"01\",\"trackKey\":\"01\",\"requestId\":\"5385910e-f853-4f34-99a4-d2ed94f02f6d\"}"}}
 
@@ -131,7 +147,7 @@ class YotoMQTTClient:
         # restart the player
 
         topic = f"device/{deviceId}/command/reboot"
-        self.client.publish(topic)
+        self._publish(topic)
 
     # control bluetooth on the player
     # action: "on" (turn on), "off" (turn off), "is-on" (check if bluetooth is on)
@@ -150,14 +166,14 @@ class YotoMQTTClient:
                 "mac": mac,
             }
         )
-        self.client.publish(topic, str(payload))
+        self._publish(topic, str(payload))
 
     # set the ambient light of the player
     # red, blue, green values of intensity from 0-255
     def set_ambients(self, deviceId: str, r: int, g: int, b: int) -> None:
         topic = f"device/{deviceId}/command/ambients/set"
         payload = json.dumps({"r": r, "g": g, "b": b})
-        self.client.publish(topic, str(payload))
+        self._publish(topic, str(payload))
 
     def _parse_status_message(self, message, player: YotoPlayer) -> None:
         status = get_child_value(message, "status") or message

--- a/yoto_api/YotoManager.py
+++ b/yoto_api/YotoManager.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timedelta
 import logging
+from typing import Optional
 import pytz
 
 from .YotoAPI import YotoAPI
@@ -16,11 +17,9 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class YotoManager:
-    def __init__(self, client_id: str) -> None:
-        if not client_id:
-            raise ValueError("A client_id must be provided")
-        self.client_id: str = client_id
-        self.api: YotoAPI = YotoAPI(client_id=self.client_id)
+    def __init__(self, client_id: Optional[str] = None) -> None:
+        self.client_id: Optional[str] = client_id
+        self.api: YotoAPI = YotoAPI(client_id=client_id)
         self.players: dict = {}
         self.token: Token = None
         self.library: dict = {}
@@ -46,6 +45,9 @@ class YotoManager:
         if self.mqtt_client:
             for player in self.players:
                 self.mqtt_client.update_status(player)
+
+    def update_player_list(self) -> None:
+        self.api.update_player_list(self.token, self.players)
 
     def connect_to_events(self, callback=None) -> None:
         # Starts and connects to MQTT.  Runs a loop to receive events. Callback is called when event has been processed and player updated.

--- a/yoto_api/YotoPlayer.py
+++ b/yoto_api/YotoPlayer.py
@@ -89,6 +89,11 @@ class YotoPlayer:
     battery_level_percentage: Optional[int] = None
     battery_temperature: Optional[int] = None
 
+    @property
+    def model(self) -> str:
+        family = (self.device_family or "").lower()
+        return "Yoto Mini" if family == "mini" else "Yoto Player"
+
 
 # {'devices': [{'deviceId': 'XXXX', 'name': 'Yoto Player', 'description': 'nameless.limit', 'online': False, 'releaseChannel': 'general', 'deviceType': 'v3', 'deviceFamily': 'v3', 'deviceGroup': '', 'hasUserGivenName': False}]}
 # Device Status API: {'activeCard': 'none', 'ambientLightSensorReading': 0, 'averageDownloadSpeedBytesSecond': 0, 'batteryLevelPercentage': 100, 'buzzErrors': 0, 'cardInsertionState': 2, 'dayMode': 0, 'deviceId': 'XXXX', 'errorsLogged': 210, 'firmwareVersion': 'v2.17.5', 'freeDiskSpaceBytes': 30250544, 'isAudioDeviceConnected': False, 'isBackgroundDownloadActive': False, 'isBluetoothAudioConnected': False, 'isCharging': False, 'isOnline': True, 'networkSsid': 'XXXX', 'nightlightMode': '0x000000', 'playingSource': 0, 'powerCapabilities': '0x02', 'powerSource': 2, 'systemVolumePercentage': 47, 'taskWatchdogTimeoutCount': 0, 'temperatureCelcius': '20', 'totalDiskSpaceBytes': 31385600, 'updatedAt': '2024-04-23T01:26:19.927Z', 'uptime': 252342, 'userVolumePercentage': 50, 'utcOffsetSeconds': -21600, 'utcTime': 1713835609, 'wifiStrength': -61}

--- a/yoto_api/YotoPlayer.py
+++ b/yoto_api/YotoPlayer.py
@@ -39,7 +39,13 @@ class YotoPlayer:
     # Device API
     id: Optional[str] = None
     name: Optional[str] = None
+    description: Optional[str] = None
     device_type: Optional[str] = None
+    device_family: Optional[str] = None
+    device_group: Optional[str] = None
+    generation: Optional[str] = None
+    form_factor: Optional[str] = None
+    release_channel: Optional[str] = None
     online: Optional[bool] = None
     last_updated_at: Optional[datetime.datetime] = None
 

--- a/yoto_api/YotoPlayer.py
+++ b/yoto_api/YotoPlayer.py
@@ -46,6 +46,7 @@ class YotoPlayer:
     generation: Optional[str] = None
     form_factor: Optional[str] = None
     release_channel: Optional[str] = None
+    mac: Optional[str] = None
     online: Optional[bool] = None
     last_updated_at: Optional[datetime.datetime] = None
 

--- a/yoto_api/__init__.py
+++ b/yoto_api/__init__.py
@@ -8,4 +8,4 @@ from .YotoAPI import YotoAPI
 from .Token import Token
 from .YotoMQTTClient import YotoMQTTClient
 from .const import LIGHT_COLORS, HEX_COLORS, VOLUME_MAPPING_INVERTED, POWER_SOURCE
-from .exceptions import AuthenticationError
+from .exceptions import AuthenticationError, YotoAPIError, YotoError, YotoMQTTError

--- a/yoto_api/exceptions.py
+++ b/yoto_api/exceptions.py
@@ -1,17 +1,21 @@
 """exceptions.py"""
 
 
-class YotoException(Exception):
+class YotoError(Exception):
+    pass
+
+
+class AuthenticationError(YotoError):
     """
-    Generic YotoException exception.
+    Raised upon receipt of an authentication error.
     """
 
     pass
 
 
-class AuthenticationError(YotoException):
-    """
-    Raised upon receipt of an authentication error.
-    """
+class YotoAPIError(YotoError):
+    pass
 
+
+class YotoMQTTError(YotoError):
     pass


### PR DESCRIPTION
## Summary

Set of upstream changes so the Home Assistant core `yoto` integration can use this library cleanly, without having to work around it. Same library, more flexible to embed.

## What's new

- **One exception type to catch.** Every library failure (network, auth, MQTT) now derives from a single `YotoError`, so integrators can handle errors in one place instead of guessing which third-party exception might surface.
- **Lightweight device refresh.** New `update_player_list()` method that just lists the user's players, without the extra status calls. Useful when live state is already coming through MQTT, or when the integration's API access doesn't include the device-status permission.
- **Drop-in for token-managed clients.** `YotoManager()` no longer requires a `client_id` upfront. Integrations that handle OAuth themselves (like Home Assistant core) can construct it without passing a placeholder.
- **More device info out of the box.** `YotoPlayer` now exposes the device's description, family, generation, form factor, and release channel. Lets Home Assistant show a richer device card (model, hardware revision) with no extra calls.

## Compatibility

Existing HACS users (`yoto_ha`) are unaffected: same imports, same methods, same behavior. The only thing to know is that some API errors now surface as `YotoError` subclasses instead of raw `requests` exceptions, so any code catching `requests.RequestException` directly should switch to `YotoError`.
