### PR TITLE
feat!: require Python 3.10+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,15 @@ test_requirements = [
 setup(
     author="cdnninja",
     author_email="",
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
-        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     description="A python package that makes it a bit easier to work with the yoto play API. Not associated with Yoto in any way.",
     install_requires=requirements,


### PR DESCRIPTION
## Summary

The async rewrite in #177 / v2.5.0 ships type hints using PEP 604 union syntax (`str | None`), which is only valid at runtime on Python 3.10+. The package was installable on 3.9 via `python_requires=">=3.9"` but would crash at import time.

Bumping `python_requires` to `>=3.10` so pip refuses to install on 3.9 cleanly instead.

Note: the `feat!:` prefix + `BREAKING CHANGE:` footer is intentional — it should trigger semantic-release to bump v2.5.0 to v3.0.0, which better reflects the actual scope of the changes shipped in #177 (full API rewrite, sync → async).