### PR TITLE
feat: scope-aware status + explicit subscription set

### DIFF
--- a/MIGRATION_3.md
+++ b/MIGRATION_3.md
@@ -70,7 +70,7 @@ so the refresh cadence (REST poll vs MQTT push) is explicit.
 -manager.update_players_status()
 -manager.connect_to_events(callback)
 +await client.refresh()
-+await client.connect_events(player_ids, on_update=cb, on_disconnect=cb)
++await client.connect_events(on_update=cb, on_disconnect=cb)
 ```
 
 MQTT auto-reconnects with exponential backoff. `on_disconnect(err)`

--- a/MIGRATION_3.md
+++ b/MIGRATION_3.md
@@ -70,12 +70,14 @@ so the refresh cadence (REST poll vs MQTT push) is explicit.
 -manager.update_players_status()
 -manager.connect_to_events(callback)
 +await client.refresh()
-+await client.connect_events(on_update=cb, on_disconnect=cb)
++await client.connect_events(player_ids, on_update=cb, on_disconnect=cb)
 ```
 
-MQTT auto-reconnects with exponential backoff. `on_disconnect(err)`
-fires on each drop with the underlying exception. Both callbacks may be
-sync or async.
+`player_ids` is the explicit subscription set. Amend it later with
+`subscribe_player_events(id)` / `unsubscribe_player_events(id)`.
+MQTT auto-reconnects with exponential backoff on broker drops.
+`on_disconnect(err)` fires each time with the underlying exception.
+Both callbacks may be sync or async.
 
 ## Settings
 
@@ -146,8 +148,11 @@ Transport errors from `aiohttp` / `aiomqtt` are wrapped into
 
 ## OAuth scope
 
-3.0 no longer needs `family:device-status:view`. When `/status` returns
-403, the lib transparently reads `device.status` from `/config`.
+3.0 no longer needs `family:device-status:view`. The lib pre-checks
+the scope on the JWT and reads `device.status` from `/config` directly
+when missing. The `/status` 403 fallback stays in place if the JWT
+disagrees with the API. Use `has_scope(access_token, scope)` if you
+need to gate features on what's granted.
 
 ## Unchanged
 

--- a/README.md
+++ b/README.md
@@ -127,11 +127,12 @@ await client.set_alarms(player_id, alarms=[...])
 await client.set_alarm_enabled(player_id, index=0, enabled=False)
 ```
 
-Account ID (no API call, decodes the JWT sub claim):
+JWT helpers (no API call):
 
 ```python
-from yoto_api import get_account_id
+from yoto_api import get_account_id, has_scope
 account_id = get_account_id(client.token.access_token)
+can_status = has_scope(client.token.access_token, "family:device-status:view")
 ```
 
 ## Errors

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ MQTT:
 
 ```python
 await client.connect_events(player_ids, on_update=cb, on_disconnect=cb)
+await client.subscribe_player_events(device_id)
+await client.unsubscribe_player_events(device_id)
 client.is_mqtt_connected
 await client.reconnect_events()
 await client.disconnect_events()

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,14 +1,13 @@
-"""JWT helper for extracting the Auth0 `sub` claim."""
+"""JWT helpers: account id + scope check."""
 
 import unittest
 
-from yoto_api import YotoError
-from yoto_api import get_account_id
+from yoto_api import YotoError, get_account_id, has_scope
 
 from .conftest import fake_jwt
 
 
-class JWTHelperTests(unittest.TestCase):
+class GetAccountIdTests(unittest.TestCase):
     def test_extracts_sub_claim(self) -> None:
         token = fake_jwt({"sub": "auth0|abc123", "iat": 1234567890})
         self.assertEqual(get_account_id(token), "auth0|abc123")
@@ -25,6 +24,29 @@ class JWTHelperTests(unittest.TestCase):
     def test_raises_on_garbage(self) -> None:
         with self.assertRaises(YotoError):
             get_account_id("not-a-jwt")
+
+
+class HasScopeTests(unittest.TestCase):
+    def test_present_scope_returns_true(self) -> None:
+        token = fake_jwt({"scope": "openid family:device-status:view profile"})
+        self.assertTrue(has_scope(token, "family:device-status:view"))
+
+    def test_missing_scope_returns_false(self) -> None:
+        token = fake_jwt({"scope": "openid profile"})
+        self.assertFalse(has_scope(token, "family:device-status:view"))
+
+    def test_no_scope_claim_returns_false(self) -> None:
+        token = fake_jwt({"sub": "x"})
+        self.assertFalse(has_scope(token, "family:device-status:view"))
+
+    def test_malformed_token_fails_open(self) -> None:
+        # We can't decode → assume the scope is there and let the API decide.
+        self.assertTrue(has_scope("not-a-jwt", "family:device-status:view"))
+
+    def test_partial_scope_match_does_not_count(self) -> None:
+        # Must be a whole-word match — "view" should not match "view-all".
+        token = fake_jwt({"scope": "family:device-status:view-all"})
+        self.assertFalse(has_scope(token, "family:device-status:view"))
 
 
 if __name__ == "__main__":

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -141,52 +141,25 @@ class MqttSurfaceTests(_ClientTestCase):
         self.assertIs(connect_calls[1][2], disconnect_cb)
 
 
-class DynamicPlayerSubscribeTests(_ClientTestCase):
-    """update_player_list should auto add/remove MQTT subscriptions."""
+class UpdatePlayerListDoesNotTouchMqttTests(_ClientTestCase):
+    """Regression guard: update_player_list manages `self.players` only,
+    never the MQTT subscription set."""
 
-    async def test_new_device_triggers_add_player(self) -> None:
+    async def test_no_auto_subscribe_on_new_device(self) -> None:
         client = self.make_client()
         client.token = fresh_token()
         client._mqtt = MagicMock()
         client._mqtt.add_player = AsyncMock()
         client._mqtt.remove_player = AsyncMock()
-
-        existing = Device(device_id="known", name="Known")
-        new = Device(device_id="new", name="New")
         client._rest.list_devices = AsyncMock(
-            side_effect=[
-                [(existing, True)],
-                [(existing, True), (new, True)],
-            ]
+            return_value=[(Device(device_id="new", name="New"), True)]
         )
 
         await client.update_player_list()
-        client._mqtt.add_player.assert_awaited_once_with("known")
 
-        client._mqtt.add_player.reset_mock()
-        await client.update_player_list()
-        client._mqtt.add_player.assert_awaited_once_with("new")
-
-    async def test_removed_device_triggers_remove_player(self) -> None:
-        client = self.make_client()
-        client.token = fresh_token()
-        client._mqtt = MagicMock()
-        client._mqtt.add_player = AsyncMock()
-        client._mqtt.remove_player = AsyncMock()
-
-        a = Device(device_id="a", name="A")
-        b = Device(device_id="b", name="B")
-        client._rest.list_devices = AsyncMock(
-            side_effect=[
-                [(a, True), (b, False)],
-                [(a, True)],
-            ]
-        )
-
-        await client.update_player_list()
-        await client.update_player_list()
-        client._mqtt.remove_player.assert_awaited_once_with("b")
-        self.assertNotIn("b", client.players)
+        client._mqtt.add_player.assert_not_awaited()
+        client._mqtt.remove_player.assert_not_awaited()
+        self.assertIn("new", client.players)
 
 
 class SetPlayerConfigTests(_ClientTestCase):

--- a/yoto_api/__init__.py
+++ b/yoto_api/__init__.py
@@ -3,7 +3,7 @@
 
 from .Card import Card, Chapter, Track
 from .Token import Token
-from .account import get_account_id
+from .account import get_account_id, has_scope
 from .capabilities import Capabilities, caps_for
 from .client import YotoClient
 from .const import HEX_COLORS, LIGHT_COLORS, POWER_SOURCE, VOLUME_MAPPING_INVERTED
@@ -57,4 +57,5 @@ __all__ = [
     "YotoPlayer",
     "caps_for",
     "get_account_id",
+    "has_scope",
 ]

--- a/yoto_api/account.py
+++ b/yoto_api/account.py
@@ -1,35 +1,52 @@
-"""Account identification helpers.
+"""Access token helpers — decode JWT claims locally.
 
-Yoto uses Auth0 for OAuth, so the access token is a JWT whose `sub` claim
-uniquely identifies the user account. Decoding it locally avoids hitting
-the undocumented `/user/family` endpoint just to get an identifier for
-HA's config entry.
+Yoto uses Auth0 for OAuth, so the access token is a JWT. Decoding it
+in-process avoids extra API calls for things that are already in the
+token (user identity, granted scopes).
 """
 
 import base64
 import json
+from typing import Any, Dict
 
 from .exceptions import YotoError
 
 
 def get_account_id(access_token: str) -> str:
-    """Return the Auth0 `sub` claim from the access token's JWT.
+    """Return the Auth0 `sub` claim from the access token.
 
-    Stable per-account identifier, no API call. Raises YotoError if the
-    token is malformed.
+    Stable per-account identifier, no API call. Raises `YotoError` if
+    the token is malformed.
     """
+    sub = _decode_jwt_payload(access_token).get("sub")
+    if not sub:
+        raise YotoError("access_token missing `sub` claim")
+    return sub
+
+
+def has_scope(access_token: str, scope: str) -> bool:
+    """True if the access token grants the given OAuth scope.
+
+    Fail-open on malformed tokens (returns True) so the caller still
+    attempts the call — the API will reject it with 403 if the scope is
+    actually missing. Use to skip known-doomed calls (e.g. HA core
+    typically lacks `family:device-status:view`).
+    """
+    try:
+        granted = _decode_jwt_payload(access_token).get("scope", "")
+    except YotoError:
+        return True
+    return scope in str(granted).split()
+
+
+def _decode_jwt_payload(access_token: str) -> Dict[str, Any]:
+    """Decode and return the payload (middle segment) of a JWT."""
     try:
         payload_b64 = access_token.split(".")[1]
     except (AttributeError, IndexError) as err:
         raise YotoError(f"access_token is not a JWT: {err}") from err
-
     payload_b64 += "=" * (-len(payload_b64) % 4)
     try:
-        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+        return json.loads(base64.urlsafe_b64decode(payload_b64))
     except (ValueError, UnicodeDecodeError) as err:
         raise YotoError(f"access_token payload not decodable: {err}") from err
-
-    sub = payload.get("sub")
-    if not sub:
-        raise YotoError("access_token missing `sub` claim")
-    return sub

--- a/yoto_api/account.py
+++ b/yoto_api/account.py
@@ -1,9 +1,4 @@
-"""Access token helpers — decode JWT claims locally.
-
-Yoto uses Auth0 for OAuth, so the access token is a JWT. Decoding it
-in-process avoids extra API calls for things that are already in the
-token (user identity, granted scopes).
-"""
+"""Access token helpers: decode JWT claims locally."""
 
 import base64
 import json
@@ -13,11 +8,7 @@ from .exceptions import YotoError
 
 
 def get_account_id(access_token: str) -> str:
-    """Return the Auth0 `sub` claim from the access token.
-
-    Stable per-account identifier, no API call. Raises `YotoError` if
-    the token is malformed.
-    """
+    """Return the Auth0 `sub` claim. Raises `YotoError` if malformed."""
     sub = _decode_jwt_payload(access_token).get("sub")
     if not sub:
         raise YotoError("access_token missing `sub` claim")
@@ -25,12 +16,10 @@ def get_account_id(access_token: str) -> str:
 
 
 def has_scope(access_token: str, scope: str) -> bool:
-    """True if the access token grants the given OAuth scope.
+    """True if the access token grants `scope`.
 
-    Fail-open on malformed tokens (returns True) so the caller still
-    attempts the call — the API will reject it with 403 if the scope is
-    actually missing. Use to skip known-doomed calls (e.g. HA core
-    typically lacks `family:device-status:view`).
+    Fails open on malformed tokens so the caller still attempts the API
+    call and gets the real 403 if relevant.
     """
     try:
         granted = _decode_jwt_payload(access_token).get("scope", "")
@@ -40,7 +29,6 @@ def has_scope(access_token: str, scope: str) -> bool:
 
 
 def _decode_jwt_payload(access_token: str) -> Dict[str, Any]:
-    """Decode and return the payload (middle segment) of a JWT."""
     try:
         payload_b64 = access_token.split(".")[1]
     except (AttributeError, IndexError) as err:

--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -195,8 +195,9 @@ class YotoClient:
     async def update_player_list(self) -> None:
         """GET /devices/mine. Adds new players, updates identity + online state.
 
-        If MQTT is connected, new players are auto-subscribed and removed
-        ones are unsubscribed.
+        Does not touch MQTT subscriptions — call
+        `subscribe_player_events(id)` / `unsubscribe_player_events(id)`
+        if you want to react to newly discovered or removed devices.
         """
         token = await self.check_and_refresh_token()
         devices_with_online = await self._rest.list_devices(token)
@@ -208,8 +209,6 @@ class YotoClient:
             if existing is None:
                 player = YotoPlayer(device=device, devices_refreshed_at=now)
                 self.players[device.device_id] = player
-                if self._mqtt is not None:
-                    await self._mqtt.add_player(device.device_id)
             else:
                 existing.device = device
                 existing.devices_refreshed_at = now
@@ -219,8 +218,6 @@ class YotoClient:
         # Players removed from the family upstream
         for stale_id in set(self.players) - seen_ids:
             self.players.pop(stale_id, None)
-            if self._mqtt is not None:
-                await self._mqtt.remove_player(stale_id)
 
     # ─── Per-player config + status ───────────────────────────────
 
@@ -574,6 +571,11 @@ class YotoClient:
     ) -> None:
         """Subscribe to MQTT for the given players.
 
+        The subscription set is explicit: this list is what the lib
+        will track until you call `subscribe_player_events(id)` /
+        `unsubscribe_player_events(id)` to amend it, or
+        `reconnect_events` to replace the whole set.
+
         Returns once the first subscribe completes, so commands fired
         right after won't race the broker. The connection auto-
         reconnects on transient drops; `on_disconnect(err)` fires each
@@ -610,6 +612,20 @@ class YotoClient:
             on_update=on_update,
             on_disconnect=on_disconnect,
         )
+
+    async def subscribe_player_events(self, device_id: str) -> None:
+        """Add a player to the live MQTT event subscription set."""
+        if device_id not in self._connected_player_ids:
+            self._connected_player_ids.append(device_id)
+        if self._mqtt is not None:
+            await self._mqtt.add_player(device_id)
+
+    async def unsubscribe_player_events(self, device_id: str) -> None:
+        """Drop a player from the live MQTT event subscription set."""
+        if device_id in self._connected_player_ids:
+            self._connected_player_ids.remove(device_id)
+        if self._mqtt is not None:
+            await self._mqtt.remove_player(device_id)
 
     @property
     def is_mqtt_connected(self) -> bool:

--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -195,9 +195,8 @@ class YotoClient:
     async def update_player_list(self) -> None:
         """GET /devices/mine. Adds new players, updates identity + online state.
 
-        Does not touch MQTT subscriptions — call
-        `subscribe_player_events(id)` / `unsubscribe_player_events(id)`
-        if you want to react to newly discovered or removed devices.
+        Does not touch MQTT subscriptions. Use `subscribe_player_events`
+        / `unsubscribe_player_events` to react to discovered devices.
         """
         token = await self.check_and_refresh_token()
         devices_with_online = await self._rest.list_devices(token)
@@ -571,15 +570,10 @@ class YotoClient:
     ) -> None:
         """Subscribe to MQTT for the given players.
 
-        The subscription set is explicit: this list is what the lib
-        will track until you call `subscribe_player_events(id)` /
-        `unsubscribe_player_events(id)` to amend it, or
-        `reconnect_events` to replace the whole set.
-
-        Returns once the first subscribe completes, so commands fired
-        right after won't race the broker. The connection auto-
-        reconnects on transient drops; `on_disconnect(err)` fires each
-        time. Both callbacks may be sync or async.
+        Returns once the first subscribe completes. The connection
+        auto-reconnects on transient drops; `on_disconnect(err)` fires
+        each time. Callbacks may be sync or async. Amend the set later
+        with `subscribe_player_events` / `unsubscribe_player_events`.
         """
         if self.token is None:
             raise YotoError("No token; authenticate before connecting MQTT")
@@ -614,14 +608,12 @@ class YotoClient:
         )
 
     async def subscribe_player_events(self, device_id: str) -> None:
-        """Add a player to the live MQTT event subscription set."""
         if device_id not in self._connected_player_ids:
             self._connected_player_ids.append(device_id)
         if self._mqtt is not None:
             await self._mqtt.add_player(device_id)
 
     async def unsubscribe_player_events(self, device_id: str) -> None:
-        """Drop a player from the live MQTT event subscription set."""
         if device_id in self._connected_player_ids:
             self._connected_player_ids.remove(device_id)
         if self._mqtt is not None:

--- a/yoto_api/mqtt/client.py
+++ b/yoto_api/mqtt/client.py
@@ -28,13 +28,11 @@ Message = Union[PlaybackEvent, StatusPatch]
 Callback = Callable[[Message], Union[None, Awaitable[None]]]
 DisconnectCallback = Callable[[Optional[Exception]], Union[None, Awaitable[None]]]
 
-# Topics we actually consume. The `response` topic also exists (ACKs
-# for our commands) but the lib doesn't use it, so we don't subscribe.
+# `response` (command ACKs) also exists but the lib doesn't consume it.
 _SUBSCRIBED_TOPICS = ("data/events", "data/status")
 
 
 async def _maybe_await(result) -> None:
-    """Await `result` if it's a coroutine, drop it otherwise."""
     if inspect.isawaitable(result):
         await result
 

--- a/yoto_api/mqtt/client.py
+++ b/yoto_api/mqtt/client.py
@@ -28,6 +28,10 @@ Message = Union[PlaybackEvent, StatusPatch]
 Callback = Callable[[Message], Union[None, Awaitable[None]]]
 DisconnectCallback = Callable[[Optional[Exception]], Union[None, Awaitable[None]]]
 
+# Topics we actually consume. The `response` topic also exists (ACKs
+# for our commands) but the lib doesn't use it, so we don't subscribe.
+_SUBSCRIBED_TOPICS = ("data/events", "data/status")
+
 
 async def _maybe_await(result) -> None:
     """Await `result` if it's a coroutine, drop it otherwise."""
@@ -116,7 +120,7 @@ class YotoMqttClient:
         self._volume_max.pop(player_id, None)
         if not self.is_connected:
             return
-        for suffix in ("data/events", "data/status", "response"):
+        for suffix in _SUBSCRIBED_TOPICS:
             try:
                 await self._client.unsubscribe(f"device/{player_id}/{suffix}")
             except Exception as err:
@@ -306,7 +310,7 @@ class YotoMqttClient:
     async def _subscribe_player(self, player_id: str) -> None:
         if self._client is None:
             return
-        for suffix in ("data/events", "data/status", "response"):
+        for suffix in _SUBSCRIBED_TOPICS:
             await self._client.subscribe(f"device/{player_id}/{suffix}")
         _LOGGER.debug("%s - subscribed to player %s", DOMAIN, player_id)
 

--- a/yoto_api/rest/client.py
+++ b/yoto_api/rest/client.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 
 import aiohttp
 
+from ..account import has_scope
 from ..const import DOMAIN
 from ..exceptions import AuthenticationError, YotoAPIError
 from ..Token import Token
@@ -94,24 +95,27 @@ class RestClient:
     async def get_player_status(self, token: Token, device_id: str) -> PlayerStatus:
         """Force a fresh telemetry snapshot.
 
-        Tries the documented /status endpoint first. If the token doesn't
-        carry `family:device-status:view` (HTTP 403), falls back to reading
-        the `device.status` sub-block out of /config.
+        Uses the documented /status endpoint when the token grants
+        `family:device-status:view`, otherwise reads the `device.status`
+        sub-block out of /config. Also falls back on a runtime 403 in
+        case the JWT claim and the API's view disagree.
         """
-        try:
-            raw = await self._get(
-                token,
-                endpoints.device_status(device_id),
-                f"get player {device_id} status",
-            )
-            return _parse_status_response(raw, device_id)
-        except YotoAPIError as err:
-            if not _is_scope_403(err):
-                raise
-            _LOGGER.debug(
-                "%s - /status forbidden, falling back to /config.device.status",
-                DOMAIN,
-            )
+        if has_scope(token.access_token, "family:device-status:view"):
+            try:
+                raw = await self._get(
+                    token,
+                    endpoints.device_status(device_id),
+                    f"get player {device_id} status",
+                )
+                return _parse_status_response(raw, device_id)
+            except YotoAPIError as err:
+                if not _is_scope_403(err):
+                    raise
+                _LOGGER.debug(
+                    "%s - /status forbidden despite scope; falling back to "
+                    "/config.device.status",
+                    DOMAIN,
+                )
 
         config = await self._get(
             token,


### PR DESCRIPTION
## Summary

Two MQTT/REST polish changes.

**Avoid hitting `/status` without the right scope**. When the OAuth token doesn't grant `family:device-status:view`, skip the doomed REST call and read the status sub-block from `/config` directly. Saves a wasted round-trip per refresh. The 403 fallback stays in place. New `has_scope(access_token, scope)` helper for consumers that want to gate features.

**Explicit MQTT subscription management**. `update_player_list` no longer silently subscribes/unsubscribes players. Pass the device list explicitly to `connect_events`, and use the new `subscribe_player_events(id)` / `unsubscribe_player_events(id)` to amend it. MQTT auto-reconnect on broker drop is unchanged.