### PR TITLE
fix: release workflow needs full git history

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
       contents: write # git push + tag + create-release
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # semantic-release needs full history to find prior tags
       - name: Get semantic release info
         id: semantic_release_info
         uses: jossef/action-semantic-release-info@v3.0.0


### PR DESCRIPTION
The new release workflow defaults to `1.0.0` when run against a checkout that doesn't see prior tags (forks, freshly synced clones). `actions/checkout@v6` does a shallow clone by default, so `jossef/action-semantic-release-info` has no history to scan.

Add `fetch-depth: 0` so the action can find the most recent tag and bump from there.

Side effect: merging this `fix:` triggers a patch release (3.1.1), which will go through the new attested publish pipeline. The HA core requirements bot should then see the attestation on the latest PyPI version.