### PR TITLE
fix: clear battery_level_percentage when player goes offline

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -498,6 +498,33 @@ class OnlineConsolidationTests(_ClientTestCase):
         # presence proof to start with.
         self.assertFalse(player.status.is_online)
 
+    async def test_going_offline_clears_battery_level(self) -> None:
+        # The device sends a shutdown MQTT status with a stale batteryLevel
+        # reading before powering off. _set_online(False) must clear it so
+        # callers see unknown rather than a misleading value.
+        client = self.make_client()
+        device = Device(device_id="d1", name="x")
+        player = YotoPlayer(device=device)
+        client.players["d1"] = player
+        # Simulate the shutdown MQTT status arriving (battery=86, still "online").
+        await client._on_mqtt_message(
+            StatusPatch(player_id="d1", fields={"battery_level_percentage": 86}),
+        )
+        self.assertEqual(player.status.battery_level_percentage, 86)
+        # REST poll detects offline.
+        client._set_online(player, False)
+        self.assertIsNone(player.status.battery_level_percentage)
+
+    async def test_going_online_preserves_battery_level(self) -> None:
+        # Flipping back online must not wipe a legitimate reading.
+        client = self.make_client()
+        device = Device(device_id="d1", name="x")
+        player = YotoPlayer(device=device)
+        client.players["d1"] = player
+        player.status.battery_level_percentage = 42
+        client._set_online(player, True)
+        self.assertEqual(player.status.battery_level_percentage, 42)
+
 
 class PlaybackEventMergeTests(_ClientTestCase):
     """Yoto emits partial MQTT events; lib must merge non-None fields

--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -673,4 +673,10 @@ class YotoClient:
 
     def _set_online(self, player: YotoPlayer, online: bool) -> None:
         player.status.is_online = online
+        if not online:
+            # The device sends a final MQTT data/status before shutting down.
+            # That message carries a stale batteryLevel reading from the
+            # firmware's shutdown sequence, not the actual level at power-off.
+            # Clear it so callers see unknown rather than a misleading value.
+            player.status.battery_level_percentage = None
         player.status_refreshed_at = datetime.datetime.now(pytz.utc)


### PR DESCRIPTION
## Problem

When a Yoto device powers down, the library's polling cycle sends a `command/status/request` via MQTT. The device responds with a `batteryLevel` that doesn't reflect its actual charge level at power-off. 

`_apply_status_patch` stores this value faithfully, and because `_set_online(player, False)` never touched `battery_level_percentage`, the stale reading persisted until the device came back online and sent a fresh status response. In practice this means Home Assistant shows a misleading battery percentage (observed: consistently 86%, unrelated to actual charge level) any time the device is powered off.

## Root cause

`_set_online` sets `is_online` but leaves all other status fields unchanged, so the stale polling response outlives the online state.

## Fix

Clear `battery_level_percentage` in `_set_online(player, False)`. Battery level is only meaningful while the device is live; when the REST poll confirms offline, the value from the last status response is no longer reliable.

Going back online does **not** clear the field, so a legitimate reading received via MQTT right after power-on is preserved.

## Tests

Two new cases in `OnlineConsolidationTests`:
- `test_going_offline_clears_battery_level` — simulates a stale battery value arriving, then REST detecting offline; asserts the field becomes `None`.
- `test_going_online_preserves_battery_level` — confirms `_set_online(True)` leaves an existing reading intact.

## Meta

This patch was produced by Claude Code (Sonnet 4.6) with human (@sethfitz) oversight.