### PR TITLE
fix: tighten typing on Card and Token dataclasses

### DIFF
--- a/tests/e2e/test_basic.py
+++ b/tests/e2e/test_basic.py
@@ -117,6 +117,5 @@ async def test_update_card_detail(client: YotoClient) -> None:
 
     for chapter_key, chapter in card.chapters.items():
         assert chapter.key == chapter_key
-        if chapter.tracks:
-            for track_key, track in chapter.tracks.items():
-                assert track.key == track_key
+        for track_key, track in chapter.tracks.items():
+            assert track.key == track_key

--- a/yoto_api/Card.py
+++ b/yoto_api/Card.py
@@ -1,39 +1,39 @@
 """Card class"""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass
 class Track:
-    icon: str = None  # $.card.content.chapters[0].tracks[0].display.icon16x16 e.g. "https://card-content.yotoplay.com/yoto/SwcetJ..."
-    title: str = None  # $.card.content.chapters[0].tracks[0].title e.g. "Introduction"
-    duration: int = None  # $.card.content.chapters[0].tracks[0].duration e.g. 349
-    key: str = None  # $.card.content.chapters[0].tracks[0].key e.g. "01-INT"
-    format: str = None  # $.card.content.chapters[0].tracks[0].format e.g. "aac"
-    channels: str = None  # $.card.content.chapters[0].tracks[0].channels e.g. "mono"
-    trackUrl: str = None  # $.card.content.chapters[0].tracks[0].trackUrl e.g. "https://secure-media.yotoplay.com/yoto/mYZ6T..."
-    type: str = None  # $.card.content.chapters[0].tracks[0].type e.g. "audio"
+    key: str  # $.card.content.chapters[0].tracks[0].key e.g. "01-INT"
+    icon: str | None = None  # $.card.content.chapters[0].tracks[0].display.icon16x16 e.g. "https://card-content.yotoplay.com/yoto/SwcetJ..."
+    title: str | None = None  # $.card.content.chapters[0].tracks[0].title e.g. "Introduction"
+    duration: int | None = None  # $.card.content.chapters[0].tracks[0].duration e.g. 349
+    format: str | None = None  # $.card.content.chapters[0].tracks[0].format e.g. "aac"
+    channels: str | None = None  # $.card.content.chapters[0].tracks[0].channels e.g. "mono"
+    trackUrl: str | None = None  # $.card.content.chapters[0].tracks[0].trackUrl e.g. "https://secure-media.yotoplay.com/yoto/mYZ6T..."
+    type: str | None = None  # $.card.content.chapters[0].tracks[0].type e.g. "audio"
 
 
 @dataclass
 class Chapter:
-    icon: str = None  # $.card.content.chapters[0].display.icon16x16 e.g. "https://card-content.yotoplay.com/yoto/SwcetJ..."
-    title: str = None  # $.card.content.chapters[0].title e.g. "Introduction"
-    duration: int = None  # $.card.content.chapters[0].duration e.g. 349
-    key: str = None  # $.card.content.chapters[0].key e.g. "01-INT"
-    tracks: dict[Track] = None  # $.card.content.chapters[0].tracks
+    key: str  # $.card.content.chapters[0].key e.g. "01-INT"
+    icon: str | None = None  # $.card.content.chapters[0].display.icon16x16 e.g. "https://card-content.yotoplay.com/yoto/SwcetJ..."
+    title: str | None = None  # $.card.content.chapters[0].title e.g. "Introduction"
+    duration: int | None = None  # $.card.content.chapters[0].duration e.g. 349
+    tracks: dict[str, Track] = field(default_factory=dict)  # $.card.content.chapters[0].tracks
 
 
 @dataclass
 class Card:
-    id: str = None  # $.card.cardId e.g. "iYIMF"
-    title: str = None  # $.card.title e.g. "Ladybird Audio Adventures - Outer Space"
-    description: str = None  # $.card.metadata.description e.g. "The sky’s the limit for imaginations when it comes to..."
-    category: str = None  # $.card.metadata.category e.g. "stories"
-    author: str = None  # $.card.metadata.author e.g. "Ladybird Audio Adventures"
-    cover_image_large: str = None  # $.card.metadata.cover.imageL e.g. "https://card-content.yotoplay.com/yoto/pub/WgoJMZ..."
-    series_title: str = (
+    id: str  # $.card.cardId e.g. "iYIMF"
+    title: str | None = None  # $.card.title e.g. "Ladybird Audio Adventures - Outer Space"
+    description: str | None = None  # $.card.metadata.description e.g. "The sky’s the limit for imaginations when it comes to..."
+    category: str | None = None  # $.card.metadata.category e.g. "stories"
+    author: str | None = None  # $.card.metadata.author e.g. "Ladybird Audio Adventures"
+    cover_image_large: str | None = None  # $.card.metadata.cover.imageL e.g. "https://card-content.yotoplay.com/yoto/pub/WgoJMZ..."
+    series_title: str | None = (
         None  # $.card.metadata.seriestitle e.g. "Ladybird Audio Adventures Volume 1"
     )
-    series_order: int = None  # $.card.metadata.seriesorder e.g. 4
-    chapters: dict[Chapter] = None  # $.card.content.chapters
+    series_order: int | None = None  # $.card.metadata.seriesorder e.g. 4
+    chapters: dict[str, Chapter] = field(default_factory=dict)  # $.card.content.chapters

--- a/yoto_api/Card.py
+++ b/yoto_api/Card.py
@@ -6,34 +6,56 @@ from dataclasses import dataclass, field
 @dataclass
 class Track:
     key: str  # $.card.content.chapters[0].tracks[0].key e.g. "01-INT"
-    icon: str | None = None  # $.card.content.chapters[0].tracks[0].display.icon16x16 e.g. "https://card-content.yotoplay.com/yoto/SwcetJ..."
-    title: str | None = None  # $.card.content.chapters[0].tracks[0].title e.g. "Introduction"
-    duration: int | None = None  # $.card.content.chapters[0].tracks[0].duration e.g. 349
+    icon: str | None = (
+        None  # $.card.content.chapters[0].tracks[0].display.icon16x16 e.g. "https://card-content.yotoplay.com/yoto/SwcetJ..."
+    )
+    title: str | None = (
+        None  # $.card.content.chapters[0].tracks[0].title e.g. "Introduction"
+    )
+    duration: int | None = (
+        None  # $.card.content.chapters[0].tracks[0].duration e.g. 349
+    )
     format: str | None = None  # $.card.content.chapters[0].tracks[0].format e.g. "aac"
-    channels: str | None = None  # $.card.content.chapters[0].tracks[0].channels e.g. "mono"
-    trackUrl: str | None = None  # $.card.content.chapters[0].tracks[0].trackUrl e.g. "https://secure-media.yotoplay.com/yoto/mYZ6T..."
+    channels: str | None = (
+        None  # $.card.content.chapters[0].tracks[0].channels e.g. "mono"
+    )
+    trackUrl: str | None = (
+        None  # $.card.content.chapters[0].tracks[0].trackUrl e.g. "https://secure-media.yotoplay.com/yoto/mYZ6T..."
+    )
     type: str | None = None  # $.card.content.chapters[0].tracks[0].type e.g. "audio"
 
 
 @dataclass
 class Chapter:
     key: str  # $.card.content.chapters[0].key e.g. "01-INT"
-    icon: str | None = None  # $.card.content.chapters[0].display.icon16x16 e.g. "https://card-content.yotoplay.com/yoto/SwcetJ..."
+    icon: str | None = (
+        None  # $.card.content.chapters[0].display.icon16x16 e.g. "https://card-content.yotoplay.com/yoto/SwcetJ..."
+    )
     title: str | None = None  # $.card.content.chapters[0].title e.g. "Introduction"
     duration: int | None = None  # $.card.content.chapters[0].duration e.g. 349
-    tracks: dict[str, Track] = field(default_factory=dict)  # $.card.content.chapters[0].tracks
+    tracks: dict[str, Track] = field(
+        default_factory=dict
+    )  # $.card.content.chapters[0].tracks
 
 
 @dataclass
 class Card:
     id: str  # $.card.cardId e.g. "iYIMF"
-    title: str | None = None  # $.card.title e.g. "Ladybird Audio Adventures - Outer Space"
-    description: str | None = None  # $.card.metadata.description e.g. "The sky’s the limit for imaginations when it comes to..."
+    title: str | None = (
+        None  # $.card.title e.g. "Ladybird Audio Adventures - Outer Space"
+    )
+    description: str | None = (
+        None  # $.card.metadata.description e.g. "The sky’s the limit for imaginations when it comes to..."
+    )
     category: str | None = None  # $.card.metadata.category e.g. "stories"
     author: str | None = None  # $.card.metadata.author e.g. "Ladybird Audio Adventures"
-    cover_image_large: str | None = None  # $.card.metadata.cover.imageL e.g. "https://card-content.yotoplay.com/yoto/pub/WgoJMZ..."
+    cover_image_large: str | None = (
+        None  # $.card.metadata.cover.imageL e.g. "https://card-content.yotoplay.com/yoto/pub/WgoJMZ..."
+    )
     series_title: str | None = (
         None  # $.card.metadata.seriestitle e.g. "Ladybird Audio Adventures Volume 1"
     )
     series_order: int | None = None  # $.card.metadata.seriesorder e.g. 4
-    chapters: dict[str, Chapter] = field(default_factory=dict)  # $.card.content.chapters
+    chapters: dict[str, Chapter] = field(
+        default_factory=dict
+    )  # $.card.content.chapters

--- a/yoto_api/Token.py
+++ b/yoto_api/Token.py
@@ -8,9 +8,9 @@ import datetime as dt
 class Token:
     """Token"""
 
-    access_token: str = None
-    refresh_token: str = None
-    id_token: str = None
-    scope: str = None
+    access_token: str | None = None
+    refresh_token: str | None = None
+    id_token: str | None = None
+    scope: str | None = None
     valid_until: dt.datetime = dt.datetime.min
-    token_type: str = None
+    token_type: str | None = None

--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -284,7 +284,6 @@ class YotoClient:
             card = self.library.get(card_id)
             if card is None:
                 card = Card(id=card_id)
-                card.chapters = {}
                 self.library[card_id] = card
             card.title = get_child_value(item, "card.title")
             card.description = get_child_value(item, "card.metadata.description")
@@ -300,8 +299,6 @@ class YotoClient:
         if card_id not in self.library:
             self.library[card_id] = Card(id=card_id)
         card = self.library[card_id]
-        if card.chapters is None:
-            card.chapters = {}
         response = await self._rest.get_card_detail(token, card_id)
         chapters = response.get("card", {}).get("content", {}).get("chapters", [])
         for chapter_item in chapters:
@@ -319,8 +316,6 @@ class YotoClient:
                 track_key = get_raw_value(track_item, "key")
                 if track_key is None:
                     continue
-                if chapter.tracks is None:
-                    chapter.tracks = {}
                 if track_key not in chapter.tracks:
                     chapter.tracks[track_key] = Track(key=track_key)
                 track = chapter.tracks[track_key]
@@ -533,7 +528,7 @@ class YotoClient:
         playlist = [
             (chapter_key, track_key)
             for chapter_key, chapter in card.chapters.items()
-            for track_key in (chapter.tracks or {})
+            for track_key in chapter.tracks
         ]
         current = (last.chapter_key, last.track_key)
         if current not in playlist:


### PR DESCRIPTION
## Summary

The `Card`, `Chapter`, `Track`, and `Token` dataclasses had broken annotations like `field: str = None` (assigning `None` to a non-`Optional` type) and `dict[Track] = None` (missing key type). mypy strict and pyright both flagged them, and downstream code (Home Assistant `yoto` integration) had to work around it with `card.chapters or {}` everywhere.

## Changes

- Fix Optional annotations: `str = None` → `str | None = None`, same for `int`.
- Fix dict typing: `dict[Track]` → `dict[str, Track]`, `dict[Chapter]` → `dict[str, Chapter]`.
- Make identifier fields required (no default): `Card.id`, `Chapter.key`, `Track.key`. They're always set at construction by the parser, and a card/chapter/track without an identifier doesn't exist in the Yoto model.
- Default `chapters` and `tracks` to `field(default_factory=dict)` instead of `None`. A card always has chapters and a chapter always has tracks in the Yoto data model; the `None` was only an artifact of incremental parsing. Empty dict represents the "not yet loaded" state.
- Remove now-dead `is None` guards in `client.py` and `or {}` in the e2e test.

## Impact

No runtime behavior change. Pure annotation tightening plus removal of dead guards.

Downstream consumers (HA core integration) can drop their `card.chapters or {}` defensive code and trust the type.
