### PR TITLE
fix: stop logging access/refresh tokens, drop pytz, add py.typed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-pytz
 aiohttp
 aiomqtt

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     keywords="yoto_api",
     name="yoto_api",
     packages=find_packages(include=["yoto_api", "yoto_api.*"]),
+    package_data={"yoto_api": ["py.typed"]},
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/cdnninja/yoto_api",

--- a/yoto_api/Token.py
+++ b/yoto_api/Token.py
@@ -1,16 +1,17 @@
-"""Token.py"""
+"""OAuth token returned by the Auth0 flows."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import datetime as dt
 
 
 @dataclass
 class Token:
-    """Token"""
+    """Access + refresh token. Secret fields are excluded from `repr` so they
+    don't leak into logs if a Token is ever printed."""
 
-    access_token: str | None = None
-    refresh_token: str | None = None
-    id_token: str | None = None
+    access_token: str | None = field(default=None, repr=False)
+    refresh_token: str | None = field(default=None, repr=False)
+    id_token: str | None = field(default=None, repr=False)
     scope: str | None = None
     valid_until: dt.datetime = dt.datetime.min
     token_type: str | None = None

--- a/yoto_api/auth.py
+++ b/yoto_api/auth.py
@@ -11,7 +11,6 @@ from datetime import timedelta
 from typing import Optional
 
 import aiohttp
-import pytz
 
 from .const import DOMAIN
 from .exceptions import AuthenticationError, YotoAPIError, YotoError
@@ -142,7 +141,6 @@ class Auth:
                 body = await response.json(content_type=None)
         except (aiohttp.ClientError, ValueError) as err:
             raise YotoAPIError(f"Refresh token request failed: {err}") from err
-        _LOGGER.debug("%s - Refresh Token Response %s", DOMAIN, body)
         if body.get("error"):
             raise AuthenticationError("Refresh token invalid")
         return _build_token(body, scope=token.scope)
@@ -156,7 +154,7 @@ class Auth:
 
 def _build_token(body: dict, scope: Optional[str]) -> Token:
     try:
-        valid_until = datetime.datetime.now(pytz.utc) + timedelta(
+        valid_until = datetime.datetime.now(datetime.timezone.utc) + timedelta(
             seconds=int(body["expires_in"])
         )
         return Token(

--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -19,7 +19,6 @@ from datetime import timedelta
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Union
 
 import aiohttp
-import pytz
 
 from .Card import Card, Chapter, Track
 from .const import DOMAIN
@@ -180,7 +179,7 @@ class YotoClient:
             self.token.access_token is None
             or self.token.valid_until is None
             or self.token.valid_until - timedelta(hours=1)
-            <= datetime.datetime.now(pytz.utc)
+            <= datetime.datetime.now(datetime.timezone.utc)
         ):
             _LOGGER.debug("%s - access token expired or near, refreshing", DOMAIN)
             self.token = await self._auth.refresh(self.token)
@@ -200,7 +199,7 @@ class YotoClient:
         """
         token = await self.check_and_refresh_token()
         devices_with_online = await self._rest.list_devices(token)
-        now = datetime.datetime.now(pytz.utc)
+        now = datetime.datetime.now(datetime.timezone.utc)
         seen_ids: set[str] = set()
         for device, online in devices_with_online:
             seen_ids.add(device.device_id)
@@ -228,7 +227,7 @@ class YotoClient:
         player = self.players.get(device_id)
         if player is not None:
             player.info = info
-            player.info_refreshed_at = datetime.datetime.now(pytz.utc)
+            player.info_refreshed_at = datetime.datetime.now(datetime.timezone.utc)
             self._set_online(player, online)
         return info
 
@@ -334,7 +333,7 @@ class YotoClient:
         player = self.players.get(device_id)
         if player is not None:
             player.status = status
-            player.status_refreshed_at = datetime.datetime.now(pytz.utc)
+            player.status_refreshed_at = datetime.datetime.now(datetime.timezone.utc)
         return status
 
     # ─── Settings writes ──────────────────────────────────────────
@@ -634,7 +633,7 @@ class YotoClient:
             self._apply_status_patch(player, message)
         elif isinstance(message, PlaybackEvent):
             self._apply_playback_event(player, message)
-            player.last_event_received_at = datetime.datetime.now(pytz.utc)
+            player.last_event_received_at = datetime.datetime.now(datetime.timezone.utc)
             # Hand the hardware cap to the MQTT client so set_volume clamps
             # against it.
             if self._mqtt is not None and message.volume_max is not None:
@@ -664,8 +663,8 @@ class YotoClient:
             if value is None:
                 continue
             setattr(player.status, field_name, value)
-        player.status_refreshed_at = datetime.datetime.now(pytz.utc)
+        player.status_refreshed_at = datetime.datetime.now(datetime.timezone.utc)
 
     def _set_online(self, player: YotoPlayer, online: bool) -> None:
         player.status.is_online = online
-        player.status_refreshed_at = datetime.datetime.now(pytz.utc)
+        player.status_refreshed_at = datetime.datetime.now(datetime.timezone.utc)

--- a/yoto_api/utils.py
+++ b/yoto_api/utils.py
@@ -1,9 +1,9 @@
-"""utils.py"""
+"""Small helpers: nested dict/list lookups, datetime parsing, volume mapping."""
 
 import datetime
 import re
 from bisect import bisect_left
-from typing import Any
+from typing import Any, Optional
 
 
 def get_child_value(data: Any, key: str) -> Any:
@@ -33,23 +33,27 @@ def get_raw_value(data: Any, key: str) -> Any:
         try:
             value = value[x]
             continue
-        except Exception:
+        except (KeyError, TypeError):
             pass
 
         try:
             value = value[int(x)]
             continue
-        except Exception:
+        except (KeyError, IndexError, TypeError, ValueError):
             return None
     return value
 
 
-def parse_datetime(value: str, timezone) -> datetime.datetime:
+def parse_datetime(
+    value: Optional[str], timezone: datetime.tzinfo
+) -> datetime.datetime:
     if value is None:
         return datetime.datetime(2000, 1, 1, tzinfo=timezone)
 
     value = value.replace("-", "").replace("T", "").replace(":", "").replace("Z", "")
     m = re.match(r"(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})", value)
+    if m is None:
+        return datetime.datetime(2000, 1, 1, tzinfo=timezone)
     return datetime.datetime(
         year=int(m.group(1)),
         month=int(m.group(2)),
@@ -61,19 +65,16 @@ def parse_datetime(value: str, timezone) -> datetime.datetime:
     )
 
 
-def take_closest(list: list, number: int) -> int:
-    """
-    Assumes list is sorted. Returns closest value to number. Used for volume mapping.
-
-    If two numbers are equally close, return the smallest number.
-    """
-    pos = bisect_left(list, number)
+def take_closest(values: list, number: int) -> int:
+    """Return the value in sorted `values` closest to `number`. Ties go to the
+    smaller value. Used for volume mapping."""
+    pos = bisect_left(values, number)
     if pos == 0:
-        return list[0]
-    if pos == len(list):
-        return list[-1]
-    before = list[pos - 1]
-    after = list[pos]
+        return values[0]
+    if pos == len(values):
+        return values[-1]
+    before = values[pos - 1]
+    after = values[pos]
     if after - number < number - before:
         return after
     else:


### PR DESCRIPTION
`Auth.refresh` logged the token response at debug level, leaking the access and refresh tokens into shared logs. I removed that log and keep tokens secret fields out of `repr`.

Conformance cleanups alongside, found while working on HA core integration:
- Replace `pytz` with stdlib `datetime.timezone.utc` and drop the dependency.
- Add `py.typed` (PEP 561).
- Narrow the catch-all excepts and fix placeholder docstrings in `utils`.

No public API change.
