### PR TITLE
feat: add library groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,15 @@ Refresh:
 await client.update_player_list()           # /devices/mine
 await client.update_player_info(device_id)  # /config — info + info.config
 await client.update_player_status(device_id)
-await client.update_library()
+await client.update_library()               # /card/family/library — client.library
+await client.update_groups()                # /card/family/library/groups — client.groups
 await client.refresh()                      # list + all info
 ```
+
+Groups are user-defined labels over library cards (a card can sit in
+several groups at once). Each `Group` in `client.groups` carries the
+card IDs in `card_ids`; cross-reference them against `client.library`
+for the card metadata.
 
 MQTT:
 

--- a/tests/e2e/test_basic.py
+++ b/tests/e2e/test_basic.py
@@ -119,3 +119,21 @@ async def test_update_card_detail(client: YotoClient) -> None:
         assert chapter.key == chapter_key
         for track_key, track in chapter.tracks.items():
             assert track.key == track_key
+
+
+async def test_update_groups(client: YotoClient) -> None:
+    """`update_groups` populates self.groups; card_ids cross-reference
+    the library."""
+    await client.update_groups()
+    if not client.groups:
+        pytest.skip("no groups in this account's library")
+
+    await client.update_library()
+    for group_id, group in client.groups.items():
+        assert group.id == group_id
+        assert group.name, f"group {group_id} has no name"
+        for card_id in group.card_ids:
+            # A grouped card should also exist in the main library
+            assert card_id in client.library, (
+                f"group {group_id} references unknown card {card_id}"
+            )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -686,13 +686,6 @@ class UpdateGroupsTests(_ClientTestCase):
         self.assertEqual(group.last_modified_at, datetime.datetime(2024, 2, 3, 4, 5, 6))
         self.assertEqual(group.card_ids, ["cardA", "cardB"])
 
-    async def test_falls_back_to_cards_array(self) -> None:
-        client = self._make_client(
-            [{"id": "g1", "cards": [{"cardId": "cardA"}, {"cardId": "cardB"}]}]
-        )
-        await client.update_groups()
-        self.assertEqual(client.groups["g1"].card_ids, ["cardA", "cardB"])
-
     async def test_skips_entries_without_id(self) -> None:
         client = self._make_client([{"name": "no id here"}, {"id": "g2"}])
         await client.update_groups()
@@ -721,8 +714,8 @@ class UpdateGroupsTests(_ClientTestCase):
 
 
 class GetCardGroupsResponseShapeTests(_ClientTestCase):
-    """RestClient.get_card_groups returns a list whether Yoto sends a
-    top-level array or a dict-wrapped variant."""
+    """get_card_groups returns the top-level array, or [] if the response
+    isn't a list."""
 
     def _rest(self):
         from yoto_api.rest.client import RestClient
@@ -734,12 +727,7 @@ class GetCardGroupsResponseShapeTests(_ClientTestCase):
         rest._get = AsyncMock(return_value=[{"id": "g1"}])
         self.assertEqual(await rest.get_card_groups(fresh_token()), [{"id": "g1"}])
 
-    async def test_dict_wrapped(self) -> None:
-        rest = self._rest()
-        rest._get = AsyncMock(return_value={"groups": [{"id": "g1"}]})
-        self.assertEqual(await rest.get_card_groups(fresh_token()), [{"id": "g1"}])
-
-    async def test_empty_object_yields_empty_list(self) -> None:
+    async def test_non_list_yields_empty(self) -> None:
         rest = self._rest()
         rest._get = AsyncMock(return_value={})
         self.assertEqual(await rest.get_card_groups(fresh_token()), [])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -696,6 +696,13 @@ class UpdateGroupsTests(_ClientTestCase):
         await client.update_groups()
         self.assertEqual(set(client.groups), {"g2"})
 
+    async def test_empty_group_has_no_card_ids(self) -> None:
+        # A group with no cards: items empty or absent -> card_ids == [].
+        client = self._make_client([{"id": "g1", "items": []}, {"id": "g2"}])
+        await client.update_groups()
+        self.assertEqual(client.groups["g1"].card_ids, [])
+        self.assertEqual(client.groups["g2"].card_ids, [])
+
     async def test_updates_existing_group_in_place(self) -> None:
         client = self._make_client([{"id": "g1", "name": "Old"}])
         await client.update_groups()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -682,8 +682,13 @@ class UpdateGroupsTests(_ClientTestCase):
         self.assertEqual(group.family_id, "fam1")
         self.assertEqual(group.image_id, "img1")
         self.assertEqual(group.image_url, "https://example/img.png")
-        self.assertEqual(group.created_at, datetime.datetime(2024, 1, 2, 3, 4, 5))
-        self.assertEqual(group.last_modified_at, datetime.datetime(2024, 2, 3, 4, 5, 6))
+        utc = datetime.timezone.utc
+        self.assertEqual(
+            group.created_at, datetime.datetime(2024, 1, 2, 3, 4, 5, tzinfo=utc)
+        )
+        self.assertEqual(
+            group.last_modified_at, datetime.datetime(2024, 2, 3, 4, 5, 6, tzinfo=utc)
+        )
         self.assertEqual(group.card_ids, ["cardA", "cardB"])
 
     async def test_skips_entries_without_id(self) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -647,6 +647,104 @@ class StatusFallbackTests(_ClientTestCase):
         )
 
 
+class UpdateGroupsTests(_ClientTestCase):
+    """update_groups maps the /library/groups array into self.groups,
+    pulling card IDs from `items`, and drops groups deleted upstream."""
+
+    def _make_client(self, groups_payload: list) -> YotoClient:
+        client = self.make_client()
+        client.token = fresh_token()
+        client._rest.get_card_groups = AsyncMock(return_value=groups_payload)
+        return client
+
+    async def test_maps_fields_and_card_ids(self) -> None:
+        client = self._make_client(
+            [
+                {
+                    "id": "g1",
+                    "name": "Bedtime",
+                    "familyId": "fam1",
+                    "imageId": "img1",
+                    "imageUrl": "https://example/img.png",
+                    "createdAt": "2024-01-02T03:04:05Z",
+                    "lastModifiedAt": "2024-02-03T04:05:06Z",
+                    "items": [
+                        {"contentId": "cardA", "addedAt": "2024-01-02T03:04:05Z"},
+                        {"contentId": "cardB", "addedAt": "2024-01-03T03:04:05Z"},
+                    ],
+                }
+            ]
+        )
+        await client.update_groups()
+
+        group = client.groups["g1"]
+        self.assertEqual(group.name, "Bedtime")
+        self.assertEqual(group.family_id, "fam1")
+        self.assertEqual(group.image_id, "img1")
+        self.assertEqual(group.image_url, "https://example/img.png")
+        self.assertEqual(group.created_at, datetime.datetime(2024, 1, 2, 3, 4, 5))
+        self.assertEqual(group.last_modified_at, datetime.datetime(2024, 2, 3, 4, 5, 6))
+        self.assertEqual(group.card_ids, ["cardA", "cardB"])
+
+    async def test_falls_back_to_cards_array(self) -> None:
+        client = self._make_client(
+            [{"id": "g1", "cards": [{"cardId": "cardA"}, {"cardId": "cardB"}]}]
+        )
+        await client.update_groups()
+        self.assertEqual(client.groups["g1"].card_ids, ["cardA", "cardB"])
+
+    async def test_skips_entries_without_id(self) -> None:
+        client = self._make_client([{"name": "no id here"}, {"id": "g2"}])
+        await client.update_groups()
+        self.assertEqual(set(client.groups), {"g2"})
+
+    async def test_updates_existing_group_in_place(self) -> None:
+        client = self._make_client([{"id": "g1", "name": "Old"}])
+        await client.update_groups()
+        original = client.groups["g1"]
+
+        client._rest.get_card_groups = AsyncMock(
+            return_value=[{"id": "g1", "name": "New"}]
+        )
+        await client.update_groups()
+        self.assertIs(client.groups["g1"], original)
+        self.assertEqual(client.groups["g1"].name, "New")
+
+    async def test_drops_groups_deleted_upstream(self) -> None:
+        client = self._make_client([{"id": "g1"}, {"id": "g2"}])
+        await client.update_groups()
+        self.assertEqual(set(client.groups), {"g1", "g2"})
+
+        client._rest.get_card_groups = AsyncMock(return_value=[{"id": "g1"}])
+        await client.update_groups()
+        self.assertEqual(set(client.groups), {"g1"})
+
+
+class GetCardGroupsResponseShapeTests(_ClientTestCase):
+    """RestClient.get_card_groups returns a list whether Yoto sends a
+    top-level array or a dict-wrapped variant."""
+
+    def _rest(self):
+        from yoto_api.rest.client import RestClient
+
+        return RestClient(session=MagicMock())
+
+    async def test_top_level_array(self) -> None:
+        rest = self._rest()
+        rest._get = AsyncMock(return_value=[{"id": "g1"}])
+        self.assertEqual(await rest.get_card_groups(fresh_token()), [{"id": "g1"}])
+
+    async def test_dict_wrapped(self) -> None:
+        rest = self._rest()
+        rest._get = AsyncMock(return_value={"groups": [{"id": "g1"}]})
+        self.assertEqual(await rest.get_card_groups(fresh_token()), [{"id": "g1"}])
+
+    async def test_empty_object_yields_empty_list(self) -> None:
+        rest = self._rest()
+        rest._get = AsyncMock(return_value={})
+        self.assertEqual(await rest.get_card_groups(fresh_token()), [])
+
+
 class LegacySetAlarmRemovedTests(unittest.TestCase):
     """The wipe-the-list `set_alarm` and `AlarmRequest` shouldn't exist
     in v3 anymore. Regression guard so they don't sneak back."""

--- a/yoto_api/Group.py
+++ b/yoto_api/Group.py
@@ -1,0 +1,26 @@
+"""Group class — a Yoto family library group.
+
+Groups are user-defined labels over library cards: a card can belong to
+several groups at once, and adding it to a group doesn't remove it from
+the main library. A Group holds the card IDs only; the card metadata
+itself lives in `YotoClient.library` (refresh it with `update_library`).
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+@dataclass
+class Group:
+    id: str  # $.[0].id e.g. "wXyZ1"
+    name: str | None = None  # $.[0].name e.g. "Bedtime"
+    family_id: str | None = None  # $.[0].familyId
+    image_id: str | None = None  # $.[0].imageId
+    image_url: str | None = (
+        None  # $.[0].imageUrl e.g. "https://card-content.yotoplay.com/yoto/..."
+    )
+    created_at: datetime | None = None  # $.[0].createdAt (ISO8601)
+    last_modified_at: datetime | None = None  # $.[0].lastModifiedAt (ISO8601)
+    card_ids: list[str] = field(
+        default_factory=list
+    )  # $.[0].items[].contentId (card IDs in this group)

--- a/yoto_api/Group.py
+++ b/yoto_api/Group.py
@@ -12,15 +12,14 @@ from datetime import datetime
 
 @dataclass
 class Group:
-    id: str  # $.[0].id e.g. "wXyZ1"
-    name: str | None = None  # $.[0].name e.g. "Bedtime"
-    family_id: str | None = None  # $.[0].familyId
-    image_id: str | None = None  # $.[0].imageId
-    image_url: str | None = (
-        None  # $.[0].imageUrl e.g. "https://card-content.yotoplay.com/yoto/..."
-    )
-    created_at: datetime | None = None  # $.[0].createdAt (ISO8601)
-    last_modified_at: datetime | None = None  # $.[0].lastModifiedAt (ISO8601)
-    card_ids: list[str] = field(
-        default_factory=list
-    )  # $.[0].items[].contentId (card IDs in this group)
+    """Maps the /card/family/library/groups payload: id, name, familyId,
+    imageId, imageUrl, createdAt, lastModifiedAt, items[].contentId."""
+
+    id: str
+    name: str | None = None
+    family_id: str | None = None
+    image_id: str | None = None
+    image_url: str | None = None
+    created_at: datetime | None = None  # ISO8601 in the payload
+    last_modified_at: datetime | None = None  # ISO8601 in the payload
+    card_ids: list[str] = field(default_factory=list)

--- a/yoto_api/__init__.py
+++ b/yoto_api/__init__.py
@@ -2,6 +2,7 @@
 # flake8: noqa
 
 from .Card import Card, Chapter, Track
+from .Group import Group
 from .Token import Token
 from .account import get_account_id, has_scope
 from .capabilities import Capabilities, caps_for
@@ -39,6 +40,7 @@ __all__ = [
     "DayMode",
     "Device",
     "EventPatch",
+    "Group",
     "HEX_COLORS",
     "LIGHT_COLORS",
     "POWER_SOURCE",

--- a/yoto_api/_coerce.py
+++ b/yoto_api/_coerce.py
@@ -8,7 +8,7 @@ raising, because the right thing to do for a missing/odd field is
 """
 
 import logging
-from datetime import datetime, time
+from datetime import datetime, time, timezone
 from enum import IntEnum
 from typing import Any, Optional, Tuple, Type, TypeVar
 
@@ -90,13 +90,16 @@ def _temp_part(part: str) -> Optional[int]:
 
 
 def parse_iso(value: Any) -> Optional[datetime]:
-    """Parse ISO8601 timestamps with the trailing-Z that Yoto sends."""
+    """Parse ISO8601 timestamps. Yoto sends UTC with a trailing `Z`."""
     if not isinstance(value, str):
         return None
+    # fromisoformat only accepts `Z` from 3.11; we support 3.10.
     try:
-        return datetime.fromisoformat(value.rstrip("Z"))
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return None
+    # Yoto's timestamps are UTC; pin a bare one so it isn't read as local.
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
 
 
 def parse_hhmm(value: Any) -> Optional[time]:

--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -378,7 +378,7 @@ class YotoClient:
             if group is None:
                 group = Group(id=group_id)
                 self.groups[group_id] = group
-            group.name = get_child_value(item, "name")
+            group.name = get_raw_value(item, "name")
             group.family_id = get_raw_value(item, "familyId")
             group.image_id = get_raw_value(item, "imageId")
             group.image_url = get_raw_value(item, "imageUrl")

--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -20,8 +20,10 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Union
 import aiohttp
 
 from .Card import Card, Chapter, Track
+from .Group import Group
 from .const import DOMAIN
 from .exceptions import YotoError
+from ._coerce import parse_iso
 from .Token import Token
 from .utils import get_child_value, get_raw_value
 from .auth import Auth
@@ -61,6 +63,23 @@ def _serialize_bool_01(value: Any) -> str:
 
 def _serialize_passthrough(value: Any) -> Any:
     return value
+
+
+def _extract_group_card_ids(item: Dict[str, Any]) -> List[str]:
+    """Pull the card IDs out of a group payload, in order, de-duplicated.
+
+    Yoto returns either a simplified `items` array ([{contentId, addedAt}])
+    or a full `cards` array. Prefer `items`; fall back to `cards`.
+    """
+    ids: List[str] = []
+    seen: set[str] = set()
+    for source_key, id_key in (("items", "contentId"), ("cards", "cardId")):
+        for entry in item.get(source_key) or []:
+            card_id = get_raw_value(entry, id_key)
+            if card_id and card_id not in seen:
+                seen.add(card_id)
+                ids.append(card_id)
+    return ids
 
 
 # (snake_case PlayerConfig field) -> (Yoto camelCase API key, serializer).
@@ -156,6 +175,7 @@ class YotoClient:
         self.token: Optional[Token] = None
         self.players: Dict[str, YotoPlayer] = {}
         self.library: Dict[str, Card] = {}
+        self.groups: Dict[str, Group] = {}
 
     async def __aenter__(self) -> "YotoClient":
         return self
@@ -335,6 +355,40 @@ class YotoClient:
                 track.channels = get_child_value(track_item, "channels")
                 track.type = get_child_value(track_item, "type")
                 track.trackUrl = get_child_value(track_item, "trackUrl")
+
+    async def update_groups(self) -> None:
+        """GET /card/family/library/groups — populate self.groups.
+
+        Groups are user-defined labels over library cards (a card can sit
+        in several groups). Each Group carries the card IDs only; the card
+        metadata lives in self.library — refresh it with update_library().
+
+        The endpoint returns the full set, so groups deleted upstream are
+        dropped from self.groups here.
+        """
+        token = await self.check_and_refresh_token()
+        items = await self._rest.get_card_groups(token)
+        seen_ids: set[str] = set()
+        for item in items:
+            group_id = get_raw_value(item, "id")
+            if group_id is None:
+                continue
+            seen_ids.add(group_id)
+            group = self.groups.get(group_id)
+            if group is None:
+                group = Group(id=group_id)
+                self.groups[group_id] = group
+            group.name = get_child_value(item, "name")
+            group.family_id = get_raw_value(item, "familyId")
+            group.image_id = get_raw_value(item, "imageId")
+            group.image_url = get_raw_value(item, "imageUrl")
+            group.created_at = parse_iso(get_raw_value(item, "createdAt"))
+            group.last_modified_at = parse_iso(get_raw_value(item, "lastModifiedAt"))
+            group.card_ids = _extract_group_card_ids(item)
+
+        # Groups removed upstream
+        for stale_id in set(self.groups) - seen_ids:
+            self.groups.pop(stale_id, None)
 
     async def update_player_status(self, device_id: str) -> PlayerStatus:
         """Force a fresh telemetry snapshot. Falls back to /config on 403."""

--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -66,19 +66,14 @@ def _serialize_passthrough(value: Any) -> Any:
 
 
 def _extract_group_card_ids(item: Dict[str, Any]) -> List[str]:
-    """Pull the card IDs out of a group payload, in order, de-duplicated.
-
-    Yoto returns either a simplified `items` array ([{contentId, addedAt}])
-    or a full `cards` array. Prefer `items`; fall back to `cards`.
-    """
+    """Card IDs in this group, from `items[].contentId`, in order, deduped."""
     ids: List[str] = []
     seen: set[str] = set()
-    for source_key, id_key in (("items", "contentId"), ("cards", "cardId")):
-        for entry in item.get(source_key) or []:
-            card_id = get_raw_value(entry, id_key)
-            if card_id and card_id not in seen:
-                seen.add(card_id)
-                ids.append(card_id)
+    for entry in item.get("items") or []:
+        card_id = get_raw_value(entry, "contentId")
+        if card_id and card_id not in seen:
+            seen.add(card_id)
+            ids.append(card_id)
     return ids
 
 

--- a/yoto_api/rest/client.py
+++ b/yoto_api/rest/client.py
@@ -7,7 +7,7 @@ rather than raw dicts.
 
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 import aiohttp
 
@@ -165,6 +165,23 @@ class RestClient:
         return await self._get(
             token, endpoints.card_detail(card_id), f"get card {card_id} detail"
         )
+
+    async def get_card_groups(self, token: Token) -> List[Dict[str, Any]]:
+        """GET /card/family/library/groups.
+
+        Unlike the other endpoints this returns a top-level JSON array of
+        group objects. We tolerate a dict-wrapped variant defensively.
+        """
+        raw: Any = await self._get(
+            token, endpoints.CARDS_LIBRARY_GROUPS, "get card groups"
+        )
+        if isinstance(raw, list):
+            return cast(List[Dict[str, Any]], raw)
+        if isinstance(raw, dict):
+            groups = raw.get("groups") or raw.get("cards")
+            if isinstance(groups, list):
+                return cast(List[Dict[str, Any]], groups)
+        return []
 
     # ─── Internals ────────────────────────────────────────────────
 

--- a/yoto_api/rest/client.py
+++ b/yoto_api/rest/client.py
@@ -7,7 +7,7 @@ rather than raw dicts.
 
 import json
 import logging
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional
 
 import aiohttp
 
@@ -167,21 +167,12 @@ class RestClient:
         )
 
     async def get_card_groups(self, token: Token) -> List[Dict[str, Any]]:
-        """GET /card/family/library/groups.
-
-        Unlike the other endpoints this returns a top-level JSON array of
-        group objects. We tolerate a dict-wrapped variant defensively.
-        """
+        """GET /card/family/library/groups — a top-level JSON array of groups
+        (unlike the other endpoints, which return objects)."""
         raw: Any = await self._get(
             token, endpoints.CARDS_LIBRARY_GROUPS, "get card groups"
         )
-        if isinstance(raw, list):
-            return cast(List[Dict[str, Any]], raw)
-        if isinstance(raw, dict):
-            groups = raw.get("groups") or raw.get("cards")
-            if isinstance(groups, list):
-                return cast(List[Dict[str, Any]], groups)
-        return []
+        return raw if isinstance(raw, list) else []
 
     # ─── Internals ────────────────────────────────────────────────
 

--- a/yoto_api/rest/endpoints.py
+++ b/yoto_api/rest/endpoints.py
@@ -22,6 +22,7 @@ def command_status(device_id: str) -> str:
 
 
 CARDS_LIBRARY = "/card/family/library"
+CARDS_LIBRARY_GROUPS = "/card/family/library/groups"
 
 
 def card_detail(card_id: str) -> str:


### PR DESCRIPTION
Expose the library groups a user creates in the Yoto app, the collections like "Bedtime" or "Roadtrip" where a card can sit in several at once.

`client.update_groups()` makes them available in `client.groups`: each group with its name, artwork, and the cards it contains. The Home Assistant integration (or any consumer) can now surface a user's groups and what's inside them, cross-referenced against the card library it already loads.

Fixes https://github.com/cdnninja/yoto_api/issues/171

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
