### PR TITLE
fix: fix token refresh crash when auth is managed by the caller

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -417,8 +417,7 @@ class CheckAndRefreshTokenTests(_ClientTestCase):
             access_token="access",
             refresh_token="refresh",
             token_type="Bearer",
-            valid_until=datetime.datetime.now(pytz.utc)
-            + datetime.timedelta(minutes=5),
+            valid_until=datetime.datetime.now(pytz.utc) + datetime.timedelta(minutes=5),
         )
 
     async def test_no_client_id_trusts_token(self) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,6 +16,7 @@ from yoto_api import (
     EventPatch,
     PlaybackStatus,
     StatusPatch,
+    Token,
     YotoClient,
     YotoPlayer,
 )
@@ -398,6 +399,58 @@ class RefreshTests(_ClientTestCase):
         client.update_all_player_info = fake_info
         await client.refresh()
         self.assertEqual(order, ["list", "info"])
+
+
+class CheckAndRefreshTokenTests(_ClientTestCase):
+    """Two ownership models, gated on whether a client_id was passed:
+    self-managed auth refreshes here; consumer-managed auth (e.g. HA's
+    OAuth2Session) syncs the token in and must not be self-refreshed."""
+
+    def make_client_with_id(self) -> YotoClient:
+        client = YotoClient(client_id="cid")
+        self._clients = getattr(self, "_clients", []) + [client]
+        return client
+
+    def near_expiry_token(self) -> Token:
+        # Inside the 1h self-refresh window but not actually expired.
+        return Token(
+            access_token="access",
+            refresh_token="refresh",
+            token_type="Bearer",
+            valid_until=datetime.datetime.now(pytz.utc)
+            + datetime.timedelta(minutes=5),
+        )
+
+    async def test_no_client_id_trusts_token(self) -> None:
+        # Consumer-managed auth: a near-expiry token is returned as-is and
+        # refresh is never attempted — there's no client_id to refresh with.
+        client = self.make_client()  # YotoClient() -> client_id None
+        client._auth.refresh = AsyncMock()
+        token = self.near_expiry_token()
+        client.token = token
+        result = await client.check_and_refresh_token()
+        self.assertIs(result, token)
+        client._auth.refresh.assert_not_awaited()
+
+    async def test_no_client_id_missing_access_token_raises(self) -> None:
+        client = self.make_client()
+        client.set_refresh_token("refresh")  # access_token stays None
+        with self.assertRaises(YotoError):
+            await client.check_and_refresh_token()
+
+    async def test_client_id_refreshes_near_expiry(self) -> None:
+        client = self.make_client_with_id()
+        client._auth.refresh = AsyncMock(return_value=fresh_token())
+        client.token = self.near_expiry_token()
+        await client.check_and_refresh_token()
+        client._auth.refresh.assert_awaited_once()
+
+    async def test_client_id_skips_when_fresh(self) -> None:
+        client = self.make_client_with_id()
+        client._auth.refresh = AsyncMock()
+        client.token = fresh_token()
+        await client.check_and_refresh_token()
+        client._auth.refresh.assert_not_awaited()
 
 
 class StatusFallback403Tests(_ClientTestCase):

--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -197,9 +197,17 @@ class YotoClient:
         return self.token
 
     async def check_and_refresh_token(self) -> Token:
-        """Refresh the access token if it's expired or about to expire."""
+        """Refresh the access token if it's expired or about to expire.
+
+        Without a `client_id` the caller owns the OAuth lifecycle (e.g.
+        HA's OAuth2Session) and syncs a token in; trust it, don't refresh.
+        """
         if self.token is None:
             raise YotoError("No token available; authenticate first")
+        if self._auth.client_id is None:
+            if self.token.access_token is None:
+                raise YotoError("No access token provided")
+            return self.token
         if (
             self.token.access_token is None
             or self.token.valid_until is None


### PR DESCRIPTION
## Summary

`check_and_refresh_token` always tried to self-refresh the access token when it was within 1h of expiry, even when no `client_id` was set. 
With consumer-managed auth (the HA core integration, which uses HA's `OAuth2Session` and never passes a `client_id`), this hit `Auth.refresh` and raised `client_id required for refresh_token`, failing setup with `ConfigEntryNotReady`. MQTT then never connected, so playback commands failed with "MQTT not connected".

## Fix

When no `client_id` is configured, trust the access token synced in by the caller and skip self-refresh entirely. If the access token is missing in that mode, raise a clear `No access token provided` error instead.

Self-managed auth (a `client_id` was passed) keeps the existing refresh-on-near-expiry behavior.

## Tests

Added `CheckAndRefreshTokenTests` covering both ownership models:
- no `client_id` + near-expiry token: returned as-is, no refresh
- no `client_id` + missing access token: raises `YotoError`
- with `client_id` + near-expiry token: refresh called
- with `client_id` + fresh token: no refresh

Full suite: 96 passed.
