### PR TITLE
fix: fix status push silently failing on MQTT connect

### DIFF
--- a/tests/test_mqtt_client.py
+++ b/tests/test_mqtt_client.py
@@ -1,0 +1,67 @@
+"""YotoMqttClient connect behaviour: the connect-time status push must
+actually go out (regression: it was swallowed as "MQTT not connected" because
+`_connected` was set after the push loop)."""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from yoto_api.mqtt import YotoMqttClient
+
+
+def _connected_client(*player_ids: str) -> tuple[YotoMqttClient, MagicMock]:
+    """A client wired to a mock broker, as if the aiomqtt context is live
+    (i.e. `_client` is set) but `_on_connected` hasn't run yet."""
+    client = YotoMqttClient()
+    broker = MagicMock()
+    broker.subscribe = AsyncMock()
+    broker.publish = AsyncMock()
+    client._client = broker
+    client._subscribed = set(player_ids)
+    return client, broker
+
+
+class OnConnectedStatusPushTests(unittest.IsolatedAsyncioTestCase):
+    async def test_requests_basic_and_extended_status_on_connect(self) -> None:
+        client, broker = _connected_client("dev1")
+
+        await client._on_connected()
+
+        self.assertTrue(client.is_connected)
+        topics = [call.args[0] for call in broker.publish.await_args_list]
+        # request_player_status -> events/request + status/request (basic)
+        self.assertIn("device/dev1/command/events/request", topics)
+        self.assertIn("device/dev1/command/status/request", topics)
+        # request_player_extended_status -> command/status (extended)
+        self.assertIn("device/dev1/command/status", topics)
+
+    async def test_pushes_happen_while_connected_not_swallowed(self) -> None:
+        # Regression guard: `_connected` must be set before the push loop, so
+        # `_publish`'s is_connected gate passes. If it weren't, every publish
+        # would raise YotoMQTTError before reaching the broker and the list
+        # below would be empty.
+        client, broker = _connected_client("dev1")
+        seen_connected: list[bool] = []
+
+        async def record(topic, payload=None):
+            seen_connected.append(client.is_connected)
+
+        broker.publish = AsyncMock(side_effect=record)
+
+        await client._on_connected()
+
+        self.assertTrue(seen_connected, "no publish reached the broker")
+        self.assertTrue(all(seen_connected), "a push ran while not connected")
+
+    async def test_subscribes_every_player_before_pushing(self) -> None:
+        client, broker = _connected_client("dev1", "dev2")
+
+        await client._on_connected()
+
+        subscribed = {call.args[0] for call in broker.subscribe.await_args_list}
+        for device_id in ("dev1", "dev2"):
+            self.assertIn(f"device/{device_id}/data/status", subscribed)
+            self.assertIn(f"device/{device_id}/status/full", subscribed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yoto_api/mqtt/client.py
+++ b/yoto_api/mqtt/client.py
@@ -284,12 +284,15 @@ class YotoMqttClient:
         )
 
     async def _on_connected(self) -> None:
-        """Subscribe + initial status push for every known player."""
+        """Subscribe, mark the connection live, then push basic + extended status."""
         for player_id in list(self._subscribed):
             await self._subscribe_player(player_id)
+        # Before the push loop: request_player_* gate on is_connected via _publish.
+        self._connected.set()
         for player_id in list(self._subscribed):
             try:
                 await self.request_player_status(player_id)
+                await self.request_player_extended_status(player_id)
             except Exception as err:
                 _LOGGER.debug(
                     "%s - status push at connect failed for %s: %s",
@@ -297,7 +300,6 @@ class YotoMqttClient:
                     player_id,
                     err,
                 )
-        self._connected.set()
 
     async def _handle_message(self, message: aiomqtt.Message) -> None:
         parsed = parse_message(str(message.topic), message.payload)


### PR DESCRIPTION
### Description

Player status didn't refresh when a device connected over MQTT: the connect-time request fired before the connection was marked ready, so it was dropped and status only caught up on the next poll. Now it's sent once the connection is ready, and it also pulls the extended status (wifi, battery details, power source, temperature, storage, uptime), so everything is fresh as soon as the device connects.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
