### PR TITLE
feat: add wake_screen and show_icon player commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,15 @@ await client.set_ambients(player_id, 255, 0, 0)   # RGB
 await client.next_track(player_id)
 await client.previous_track(player_id)
 await client.seek(player_id, position=30)
+await client.wake_screen(player_id)                # light the screen, no audio change
+await client.show_icon(player_id, "https://.../icon.png", timeout=10)  # show for 10s
 ```
+
+`wake_screen` re-sends the current volume (a no-op for audio) because that
+lights the display; `display/preview` alone doesn't. `show_icon` takes the
+icon's image URL and a `timeout` in seconds (required by the firmware). Pass
+`wake=True` to light the screen first. `wake_screen` needs MQTT connected and a
+volume already received over events.
 
 Settings (REST PUT):
 

--- a/scripts/_common.py
+++ b/scripts/_common.py
@@ -1,0 +1,97 @@
+"""Shared helpers for the scripts: a YotoClient session and a device picker.
+
+Not runnable on its own. Imported by the sibling scripts — running
+`python scripts/<name>.py` puts this directory on `sys.path`.
+"""
+
+import contextlib
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+from rich.console import Console
+from rich.prompt import IntPrompt
+from rich.table import Table
+
+from yoto_api import AuthenticationError, YotoClient
+from yoto_api.Token import Token
+
+console = Console()
+_ENV_PATH = Path(__file__).resolve().parent.parent / ".env"
+
+
+@contextlib.asynccontextmanager
+async def yoto_session():
+    """Authenticate from .env and yield a YotoClient.
+
+    Persists a refreshed token back to .env and closes the client on exit.
+    Raises SystemExit if YOTO_CLIENT_ID is missing.
+    """
+    load_dotenv()
+    client_id = os.environ.get("YOTO_CLIENT_ID")
+    if not client_id:
+        raise SystemExit("YOTO_CLIENT_ID missing from .env")
+    initial = os.environ.get("YOTO_REFRESH_TOKEN")
+    yoto = await _authenticate(client_id, initial)
+    try:
+        yield yoto
+    finally:
+        if initial != yoto.token.refresh_token and yoto.token.refresh_token:
+            _persist_refresh_token(yoto.token.refresh_token)
+        await yoto.close()
+
+
+def pick_device(yoto: YotoClient):
+    """Return the only device, or prompt to pick one. None if cancelled."""
+    players = list(yoto.players.values())
+    if len(players) == 1:
+        return players[0]
+
+    table = Table(title="Devices", show_header=True, header_style="bold cyan")
+    table.add_column("#", justify="right", style="bold")
+    table.add_column("Name")
+    table.add_column("Family", style="dim")
+    table.add_column("Status")
+    for i, p in enumerate(players, start=1):
+        status = "[green]online[/]" if p.is_online else "[red]offline[/]"
+        table.add_row(str(i), p.device.name, p.device.device_family or "?", status)
+    console.print(table)
+
+    try:
+        choice = IntPrompt.ask(
+            "Pick a device",
+            choices=[str(i) for i in range(1, len(players) + 1)],
+            default=1,
+        )
+    except (KeyboardInterrupt, EOFError):
+        return None
+    return players[choice - 1]
+
+
+async def _authenticate(client_id: str, refresh_token: str | None) -> YotoClient:
+    yoto = YotoClient(client_id=client_id)
+    if refresh_token:
+        yoto.token = Token(refresh_token=refresh_token)
+        try:
+            await yoto.check_and_refresh_token()
+            return yoto
+        except AuthenticationError:
+            print("Stored refresh token invalid; using device-code flow.")
+    auth = await yoto.device_code_flow_start()
+    print(f"\n  Open this URL to authorise:\n  {auth['verification_uri_complete']}\n")
+    await yoto.device_code_flow_complete(auth)
+    return yoto
+
+
+def _persist_refresh_token(new_token: str) -> None:
+    if not _ENV_PATH.exists():
+        return
+    lines = _ENV_PATH.read_text().splitlines()
+    new_line = f"YOTO_REFRESH_TOKEN={new_token}"
+    for i, line in enumerate(lines):
+        if line.startswith("YOTO_REFRESH_TOKEN="):
+            lines[i] = new_line
+            break
+    else:
+        lines.append(new_line)
+    _ENV_PATH.write_text("\n".join(lines) + "\n")

--- a/scripts/show_icon.py
+++ b/scripts/show_icon.py
@@ -1,0 +1,79 @@
+"""Show an icon on a player's screen, via the library's `show_icon()`.
+
+    python scripts/show_icon.py <uri> [timeout] [--wake] [--animated]
+    python scripts/show_icon.py "https://.../icon.png" 15
+
+`uri` is the URL of the icon image. `timeout` is the display duration in
+seconds, required by the firmware (default 10). Pass `--wake` to light the
+screen first. Watch the device to see whether the icon shows.
+
+Needs YOTO_CLIENT_ID (+ optional YOTO_REFRESH_TOKEN) in .env.
+"""
+
+import argparse
+import asyncio
+
+from yoto_api import YotoClient, YotoError
+
+from _common import console, pick_device, yoto_session
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Show an icon on a Yoto player via client.show_icon()."
+    )
+    p.add_argument("uri", help="URL of the icon image to display")
+    p.add_argument(
+        "timeout",
+        nargs="?",
+        type=int,
+        default=10,
+        help="display duration in seconds, required by the firmware (default: 10)",
+    )
+    p.add_argument(
+        "--animated",
+        action="store_true",
+        help="mark the icon as animated (default: static)",
+    )
+    p.add_argument("--wake", action="store_true", help="wake the screen first")
+    return p.parse_args()
+
+
+async def main() -> int:
+    args = _parse_args()
+    async with yoto_session() as yoto:
+        return await _run(yoto, args)
+
+
+async def _run(yoto: YotoClient, args: argparse.Namespace) -> int:
+    await yoto.update_player_list()
+    if not yoto.players:
+        console.print("No devices on this account.")
+        return 1
+
+    target = pick_device(yoto)
+    if target is None:
+        return 0
+    device_id = target.device.device_id
+
+    await yoto.connect_events([device_id])
+    try:
+        await yoto.show_icon(
+            device_id,
+            args.uri,
+            timeout=args.timeout,
+            animated=args.animated,
+            wake=args.wake,
+        )
+        console.print(f"[green]show_icon sent[/]: {args.uri} for {args.timeout}s")
+        await asyncio.sleep(1)  # let the command reach the device before disconnect
+    except YotoError as err:
+        console.print(f"[red]{err}[/]")
+        return 1
+    finally:
+        await yoto.disconnect_events()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/wake_screen.py
+++ b/scripts/wake_screen.py
@@ -1,0 +1,47 @@
+"""Wake a player's screen via the library's `wake_screen()`.
+
+    python scripts/wake_screen.py
+
+Connects over MQTT and calls `client.wake_screen(device_id)`. Watch the device.
+
+Needs YOTO_CLIENT_ID (+ optional YOTO_REFRESH_TOKEN) in .env.
+"""
+
+import asyncio
+
+from yoto_api import YotoClient, YotoError
+
+from _common import console, pick_device, yoto_session
+
+
+async def main() -> int:
+    async with yoto_session() as yoto:
+        return await _run(yoto)
+
+
+async def _run(yoto: YotoClient) -> int:
+    await yoto.update_player_list()
+    if not yoto.players:
+        console.print("No devices on this account.")
+        return 1
+
+    target = pick_device(yoto)
+    if target is None:
+        return 0
+    device_id = target.device.device_id
+
+    await yoto.connect_events([device_id])
+    try:
+        await yoto.wake_screen(device_id)
+        console.print("[green]wake_screen sent[/] — check the device")
+        await asyncio.sleep(1)  # let the command reach the device before disconnect
+    except YotoError as err:
+        console.print(f"[red]{err}[/]")
+        return 1
+    finally:
+        await yoto.disconnect_events()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -892,5 +892,63 @@ class LegacySetAlarmRemovedTests(unittest.TestCase):
         self.assertFalse(hasattr(v3, "AlarmRequest"))
 
 
+class WakeAndShowIconTests(_ClientTestCase):
+    """`wake_screen` reads the raw volume from the last event and forwards it to
+    the mqtt client (which maps it to the send step); `show_icon` wakes first
+    only if asked."""
+
+    _URL = "https://www.yotoicons.com/static/uploads/123.png"
+
+    def _client_at_cran(self, cran) -> tuple[YotoClient, MagicMock]:
+        client = self.make_client()
+        client._mqtt = MagicMock()
+        client._mqtt.is_connected = True
+        client._mqtt.wake_screen = AsyncMock()
+        client._mqtt.show_icon = AsyncMock()
+        client._mqtt.request_player_status = AsyncMock()
+        player = YotoPlayer(device=Device(device_id="d1", name="x"))
+        if cran is not None:
+            # last_event carries the raw 0-16 cran.
+            player.last_event.volume = cran
+        client.players["d1"] = player
+        return client, client._mqtt
+
+    async def test_wake_screen_forwards_reported_volume(self) -> None:
+        # the raw cran is already on last_event, so no status request is needed.
+        client, mqtt = self._client_at_cran(3)
+        await client.wake_screen("d1")
+        mqtt.request_player_status.assert_not_awaited()
+        mqtt.wake_screen.assert_awaited_once_with("d1", 3)
+
+    async def test_wake_screen_waits_for_the_status_volume(self) -> None:
+        client, mqtt = self._client_at_cran(None)
+
+        async def arrive(_device_id):
+            client.players["d1"].last_event.volume = 2
+
+        mqtt.request_player_status.side_effect = arrive
+        await client.wake_screen("d1")
+        mqtt.wake_screen.assert_awaited_once_with("d1", 2)
+
+    async def test_wake_screen_raises_when_no_volume_arrives(self) -> None:
+        client, mqtt = self._client_at_cran(None)
+        with patch("yoto_api.client._WAKE_VOLUME_TIMEOUT_S", 0.1):
+            with self.assertRaises(YotoError):
+                await client.wake_screen("d1")
+        mqtt.wake_screen.assert_not_awaited()
+
+    async def test_show_icon_does_not_wake_by_default(self) -> None:
+        client, mqtt = self._client_at_cran(3)
+        await client.show_icon("d1", self._URL, timeout=5)
+        mqtt.wake_screen.assert_not_awaited()
+        mqtt.show_icon.assert_awaited_once_with("d1", self._URL, 5, False)
+
+    async def test_show_icon_wakes_first_when_requested(self) -> None:
+        client, mqtt = self._client_at_cran(3)
+        await client.show_icon("d1", self._URL, wake=True)
+        mqtt.wake_screen.assert_awaited_once_with("d1", 3)
+        mqtt.show_icon.assert_awaited_once_with("d1", self._URL, 10, False)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_mqtt_client.py
+++ b/tests/test_mqtt_client.py
@@ -2,9 +2,11 @@
 actually go out (regression: it was swallowed as "MQTT not connected" because
 `_connected` was set after the push loop)."""
 
+import json
 import unittest
 from unittest.mock import AsyncMock, MagicMock
 
+from yoto_api.const import VOLUME_MAPPING_INVERTED
 from yoto_api.mqtt import YotoMqttClient
 
 
@@ -61,6 +63,34 @@ class OnConnectedStatusPushTests(unittest.IsolatedAsyncioTestCase):
         for device_id in ("dev1", "dev2"):
             self.assertIn(f"device/{device_id}/data/status", subscribed)
             self.assertIn(f"device/{device_id}/status/full", subscribed)
+
+
+class CommandPublishTests(unittest.IsolatedAsyncioTestCase):
+    """show_icon and wake_screen publish the documented command topics."""
+
+    async def test_show_icon_publishes_display_preview(self) -> None:
+        client, broker = _connected_client("dev1")
+        client._connected.set()
+        url = "https://www.yotoicons.com/static/uploads/123.png"
+        await client.show_icon("dev1", url, timeout=20, animated=True)
+        call = broker.publish.await_args
+        self.assertEqual(call.args[0], "device/dev1/command/display/preview")
+        self.assertEqual(
+            json.loads(call.kwargs["payload"]),
+            {"uri": url, "timeout": 20, "animated": 1},
+        )
+
+    async def test_wake_screen_maps_cran_to_send_step(self) -> None:
+        client, broker = _connected_client("dev1")
+        client._connected.set()
+        # raw cran 3 → the % that lands back on cran 3 (the no-op send value).
+        await client.wake_screen("dev1", 3)
+        call = broker.publish.await_args
+        self.assertEqual(call.args[0], "device/dev1/command/volume/set")
+        self.assertEqual(
+            json.loads(call.kwargs["payload"]),
+            {"volume": VOLUME_MAPPING_INVERTED[3]},
+        )
 
 
 if __name__ == "__main__":

--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -42,6 +42,11 @@ _LOGGER = logging.getLogger(__name__)
 UpdateCallback = Callable[[YotoPlayer], Union[None, Awaitable[None]]]
 DisconnectCallback = Callable[[Optional[Exception]], Union[None, Awaitable[None]]]
 
+# wake_screen reuses the raw volume already on the last event; only on a cold
+# connection does it ask once and poll briefly for it to arrive.
+_WAKE_VOLUME_POLL_S = 0.1
+_WAKE_VOLUME_TIMEOUT_S = 2.0
+
 
 def _serialize_hhmm(value: Any) -> str:
     if isinstance(value, datetime.time):
@@ -567,6 +572,52 @@ class YotoClient:
 
     async def restart(self, device_id: str) -> None:
         await self._require_mqtt().restart(device_id)
+
+    async def show_icon(
+        self,
+        device_id: str,
+        uri: str,
+        timeout: int = 10,
+        animated: bool = False,
+        wake: bool = False,
+    ) -> None:
+        """Show an icon on the player's screen for `timeout` seconds.
+
+        `uri` is the URL of the icon image. The screen must be on for the icon
+        to show; pass `wake=True` to wake it first.
+        """
+        if wake:
+            await self.wake_screen(device_id)
+        await self._require_mqtt().show_icon(device_id, uri, timeout, animated)
+
+    async def wake_screen(self, device_id: str) -> None:
+        """Light up the player's screen.
+
+        Needs an active event connection (`connect_events`). Raises `YotoError`
+        if the player can't be reached.
+        """
+        # Re-send the player's current volume to light the screen (a no-op for
+        # the audio). last_event carries the raw 0-16 cran, usually already there
+        # from the event stream; on a cold connection ask once (request_player_
+        # status also pushes data/events) and poll briefly for it to arrive.
+        player = self.players.get(device_id)
+        volume = player.last_event.volume if player else None
+        if volume is None:
+            await self.request_player_status(device_id)
+            for _ in range(round(_WAKE_VOLUME_TIMEOUT_S / _WAKE_VOLUME_POLL_S)):
+                await asyncio.sleep(_WAKE_VOLUME_POLL_S)
+                player = self.players.get(device_id)
+                volume = player.last_event.volume if player else None
+                if volume is not None:
+                    break
+        if volume is None:
+            raise YotoError(
+                "Can't wake: no volume received from the player "
+                "(is connect_events() running?)."
+            )
+        # wake_screen maps the raw cran to the % that re-lands on it, so it
+        # stays a no-op for the audio.
+        await self._require_mqtt().wake_screen(device_id, volume)
 
     async def request_player_status(self, device_id: str) -> None:
         """Ask the player to push a fresh `data/status` on MQTT.

--- a/yoto_api/mqtt/client.py
+++ b/yoto_api/mqtt/client.py
@@ -223,6 +223,41 @@ class YotoMqttClient:
             json.dumps({"r": int(r), "g": int(g), "b": int(b)}),
         )
 
+    async def show_icon(
+        self,
+        player_id: str,
+        uri: str,
+        timeout: int = 10,
+        animated: bool = False,
+    ) -> None:
+        """Show an icon on the player's screen for `timeout` seconds.
+
+        `uri` is the URL of the icon image. `timeout` is required by the
+        firmware (the command FAILs without one). The screen must be awake —
+        `display/preview` doesn't light a sleeping screen, so wake it first
+        (see `wake_screen`).
+        """
+        await self._publish(
+            f"device/{player_id}/command/display/preview",
+            json.dumps(
+                {"uri": uri, "timeout": int(timeout), "animated": 1 if animated else 0}
+            ),
+        )
+
+    async def wake_screen(self, player_id: str, volume: int) -> None:
+        """Wake the player's screen without changing audio.
+
+        Re-sends the current volume. `volume/set` is a command the firmware acts
+        on even when stopped, and that lights the display; `display/preview`
+        alone does not. `volume` is the raw 0-16 cran (from `last_event`), mapped
+        to the % that lands back on that exact cran, so it's a no-op for audio.
+        """
+        cran = max(0, min(int(volume), len(VOLUME_MAPPING_INVERTED) - 1))
+        await self._publish(
+            f"device/{player_id}/command/volume/set",
+            json.dumps({"volume": VOLUME_MAPPING_INVERTED[cran]}),
+        )
+
     # ─── Per-player metadata fed in by the consumer ──────────────
 
     def set_volume_max(self, player_id: str, volume_max: Optional[int]) -> None:


### PR DESCRIPTION
Two player commands over MQTT:

- `wake_screen(device_id)`: re-sends the current volume (no-op for audio), which lights the screen. `display/preview` alone doesn't wake the backlight.
- `show_icon(device_id, uri, timeout=10, animated=False, wake=False)`: shows an image by URL. `timeout` is required by the firmware; `wake=True` lights the screen first.

The volume re-send reads the raw cran from the last event and maps it to the percentage that re-lands on the same cran, so it holds the volume exactly.

Demo scripts: `scripts/wake_screen.py`, `scripts/show_icon.py` (sharing `scripts/_common.py`).