### PR TITLE
fix: fix MQTT reliability

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -116,6 +116,33 @@ class MqttSurfaceTests(_ClientTestCase):
         client._mqtt.is_connected = False
         self.assertFalse(client.is_mqtt_connected)
 
+    async def test_connect_events_passes_getter_reading_live_token(self) -> None:
+        # The MQTT client gets a token_getter that re-reads self.token on every
+        # call, so a token synced in after connect (the HA path) is picked up on
+        # the next reconnect instead of a stale snapshot.
+        client = self.make_client()
+        client.token = fresh_token()
+        captured: dict = {}
+
+        async def fake_connect(
+            token, ids, callback, on_disconnect=None, token_getter=None
+        ):
+            captured["getter"] = token_getter
+
+        with patch("yoto_api.client.YotoMqttClient") as MqttClass:
+            instance = MagicMock()
+            instance.connect = AsyncMock(side_effect=fake_connect)
+            instance.disconnect = AsyncMock()
+            MqttClass.return_value = instance
+
+            await client.connect_events(["a"])
+
+        getter = captured["getter"]
+        self.assertEqual(await getter(), "access")
+        # Rotate the synced token; the getter reflects it without reconnecting.
+        client.token = Token(access_token="rotated")
+        self.assertEqual(await getter(), "rotated")
+
     async def test_reconnect_preserves_player_list_and_callbacks(self) -> None:
         client = self.make_client()
         client.token = fresh_token()
@@ -123,7 +150,9 @@ class MqttSurfaceTests(_ClientTestCase):
         disconnect_cb = MagicMock()
         connect_calls: list[tuple] = []
 
-        async def fake_connect(token, ids, callback, on_disconnect=None):
+        async def fake_connect(
+            token, ids, callback, on_disconnect=None, token_getter=None
+        ):
             connect_calls.append((list(ids), callback, on_disconnect))
 
         with patch("yoto_api.client.YotoMqttClient") as MqttClass:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -474,6 +474,21 @@ class CheckAndRefreshTokenTests(_ClientTestCase):
         await client.check_and_refresh_token()
         client._auth.refresh.assert_awaited_once()
 
+    async def test_refresh_does_not_force_mqtt_reconnect(self) -> None:
+        # Re-entrancy guard: the MQTT token getter calls check_and_refresh_token
+        # from inside the _run task, so reconnecting here would cancel that very
+        # task and deadlock. MQTT re-resolves the token on its own next connect.
+        client = self.make_client_with_id()
+        client._auth.refresh = AsyncMock(return_value=fresh_token())
+        client.token = self.near_expiry_token()
+        client._mqtt = MagicMock()
+        client._mqtt.disconnect = AsyncMock()
+
+        await client.check_and_refresh_token()
+
+        client._auth.refresh.assert_awaited_once()
+        client._mqtt.disconnect.assert_not_awaited()  # reconnect_events not invoked
+
     async def test_client_id_skips_when_fresh(self) -> None:
         client = self.make_client_with_id()
         client._auth.refresh = AsyncMock()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -474,21 +474,6 @@ class CheckAndRefreshTokenTests(_ClientTestCase):
         await client.check_and_refresh_token()
         client._auth.refresh.assert_awaited_once()
 
-    async def test_refresh_does_not_force_mqtt_reconnect(self) -> None:
-        # Re-entrancy guard: the MQTT token getter calls check_and_refresh_token
-        # from inside the _run task, so reconnecting here would cancel that very
-        # task and deadlock. MQTT re-resolves the token on its own next connect.
-        client = self.make_client_with_id()
-        client._auth.refresh = AsyncMock(return_value=fresh_token())
-        client.token = self.near_expiry_token()
-        client._mqtt = MagicMock()
-        client._mqtt.disconnect = AsyncMock()
-
-        await client.check_and_refresh_token()
-
-        client._auth.refresh.assert_awaited_once()
-        client._mqtt.disconnect.assert_not_awaited()  # reconnect_events not invoked
-
     async def test_client_id_skips_when_fresh(self) -> None:
         client = self.make_client_with_id()
         client._auth.refresh = AsyncMock()

--- a/tests/test_mqtt_client.py
+++ b/tests/test_mqtt_client.py
@@ -1,10 +1,16 @@
 """YotoMqttClient connect behaviour: the connect-time status push must
 actually go out (regression: it was swallowed as "MQTT not connected" because
-`_connected` was set after the push loop)."""
+`_connected` was set after the push loop). Also covers the reliability fixes:
+QoS 1 on publishes/subscriptions and a fresh access token on every reconnect."""
 
+import asyncio
 import unittest
 from unittest.mock import AsyncMock, MagicMock
 
+import aiomqtt
+
+from yoto_api.Token import Token
+from yoto_api.exceptions import YotoMQTTError
 from yoto_api.mqtt import YotoMqttClient
 
 
@@ -42,7 +48,7 @@ class OnConnectedStatusPushTests(unittest.IsolatedAsyncioTestCase):
         client, broker = _connected_client("dev1")
         seen_connected: list[bool] = []
 
-        async def record(topic, payload=None):
+        async def record(topic, payload=None, qos=0):
             seen_connected.append(client.is_connected)
 
         broker.publish = AsyncMock(side_effect=record)
@@ -61,6 +67,125 @@ class OnConnectedStatusPushTests(unittest.IsolatedAsyncioTestCase):
         for device_id in ("dev1", "dev2"):
             self.assertIn(f"device/{device_id}/data/status", subscribed)
             self.assertIn(f"device/{device_id}/status/full", subscribed)
+
+
+class QoSTests(unittest.IsolatedAsyncioTestCase):
+    """QoS 1 closes the silent-drop gap a QoS-0 publish/reply leaves open."""
+
+    async def test_publishes_at_qos_1(self) -> None:
+        client, broker = _connected_client("dev1")
+        client._connected.set()
+
+        await client.request_player_status("dev1")
+
+        self.assertTrue(broker.publish.await_args_list)
+        for call in broker.publish.await_args_list:
+            self.assertEqual(call.kwargs.get("qos"), 1)
+
+    async def test_subscribes_at_qos_1(self) -> None:
+        client, broker = _connected_client("dev1")
+
+        await client._on_connected()
+
+        self.assertTrue(broker.subscribe.await_args_list)
+        for call in broker.subscribe.await_args_list:
+            self.assertEqual(call.kwargs.get("qos"), 1)
+
+
+class AccessTokenResolutionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_prefers_async_getter(self) -> None:
+        client = YotoMqttClient()
+
+        async def getter() -> str:
+            return "fresh"
+
+        client._token_getter = getter
+        self.assertEqual(await client._current_access_token(), "fresh")
+
+    async def test_accepts_sync_getter(self) -> None:
+        client = YotoMqttClient()
+        client._token_getter = lambda: "sync-fresh"
+        self.assertEqual(await client._current_access_token(), "sync-fresh")
+
+    async def test_falls_back_to_static_token(self) -> None:
+        client = YotoMqttClient()
+        client._token = Token(access_token="static")
+        self.assertEqual(await client._current_access_token(), "static")
+
+    async def test_raises_when_no_token_available(self) -> None:
+        client = YotoMqttClient()
+        client._token = Token(access_token=None)
+        with self.assertRaises(YotoMQTTError):
+            await client._current_access_token()
+
+
+class ReconnectUsesFreshTokenTests(unittest.IsolatedAsyncioTestCase):
+    """Bug 1 regression: each reconnect must authenticate with a current token,
+    not the snapshot captured at the first connect."""
+
+    async def test_reconnect_fetches_a_new_token(self) -> None:
+        client = YotoMqttClient()
+        client._BACKOFF_MIN = 0.0
+        client._BACKOFF_MAX = 0.0
+
+        tokens = iter(["tok1", "tok2", "tok3"])
+
+        async def getter() -> str:
+            return next(tokens)
+
+        passwords: list[str] = []
+        second_connect = asyncio.Event()
+
+        class FakeMessages:
+            def __init__(self, drop: bool) -> None:
+                self._drop = drop
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self._drop:
+                    raise aiomqtt.MqttError("connection dropped")
+                await asyncio.sleep(3600)  # second connect stays up
+
+        class FakeClient:
+            def __init__(self, drop: bool) -> None:
+                self.messages = FakeMessages(drop)
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_a):
+                return False
+
+            async def subscribe(self, *_a, **_k):
+                return None
+
+            async def publish(self, *_a, **_k):
+                return None
+
+        def fake_make_client(access_token: str) -> FakeClient:
+            passwords.append(access_token)
+            if len(passwords) >= 2:
+                second_connect.set()
+                return FakeClient(drop=False)
+            return FakeClient(drop=True)  # first connect drops to force reconnect
+
+        client._make_client = fake_make_client
+
+        await client.connect(
+            token=None,
+            player_ids=["dev1"],
+            callback=lambda _m: None,
+            token_getter=getter,
+        )
+        try:
+            await asyncio.wait_for(second_connect.wait(), timeout=2.0)
+        finally:
+            await client.disconnect()
+
+        self.assertEqual(passwords[0], "tok1")
+        self.assertEqual(passwords[1], "tok2")  # reconnect used the next token
 
 
 if __name__ == "__main__":

--- a/tests/test_mqtt_client.py
+++ b/tests/test_mqtt_client.py
@@ -26,19 +26,25 @@ def _connected_client(*player_ids: str) -> tuple[YotoMqttClient, MagicMock]:
     return client, broker
 
 
+class _FakeMsg:
+    def __init__(self, topic: str, payload: bytes) -> None:
+        self.topic = topic
+        self.payload = payload
+
+
 class OnConnectedStatusPushTests(unittest.IsolatedAsyncioTestCase):
-    async def test_requests_basic_and_extended_status_on_connect(self) -> None:
+    async def test_pushes_basic_status_on_connect(self) -> None:
         client, broker = _connected_client("dev1")
 
         await client._on_connected()
 
         self.assertTrue(client.is_connected)
         topics = [call.args[0] for call in broker.publish.await_args_list]
-        # request_player_status -> events/request + status/request (basic)
+        # Basic only (fire-and-forget); extended would block on the reply wait
+        # before the message loop is running, so it's left to the heartbeat.
         self.assertIn("device/dev1/command/events/request", topics)
         self.assertIn("device/dev1/command/status/request", topics)
-        # request_player_extended_status -> command/status (extended)
-        self.assertIn("device/dev1/command/status", topics)
+        self.assertNotIn("device/dev1/command/status", topics)
 
     async def test_pushes_happen_while_connected_not_swallowed(self) -> None:
         # Regression guard: `_connected` must be set before the push loop, so
@@ -75,6 +81,7 @@ class QoSTests(unittest.IsolatedAsyncioTestCase):
     async def test_publishes_at_qos_1(self) -> None:
         client, broker = _connected_client("dev1")
         client._connected.set()
+        client._STATUS_REPLY_TIMEOUT = 0.0  # don't wait for a reply the mock won't send
 
         await client.request_player_status("dev1")
 
@@ -90,6 +97,53 @@ class QoSTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(broker.subscribe.await_args_list)
         for call in broker.subscribe.await_args_list:
             self.assertEqual(call.kwargs.get("qos"), 1)
+
+
+class StatusReplyWaitTests(unittest.IsolatedAsyncioTestCase):
+    """A status request waits for its own reply, so chained basic+extended
+    requests serialise instead of racing the firmware back-to-back."""
+
+    async def test_blocks_until_reply_then_returns(self) -> None:
+        client, _ = _connected_client("dev1")
+        client._connected.set()
+        returned: list[bool] = []
+
+        async def run() -> None:
+            await client.request_player_status("dev1")
+            returned.append(True)
+
+        task = asyncio.create_task(run())
+        await asyncio.sleep(0.02)
+        self.assertFalse(returned, "returned before the reply arrived")
+
+        await client._handle_message(_FakeMsg("device/dev1/data/status", b"{}"))
+        await asyncio.wait_for(task, 1.0)
+        self.assertTrue(returned)
+
+    async def test_times_out_without_reply(self) -> None:
+        client, _ = _connected_client("dev1")
+        client._connected.set()
+        client._STATUS_REPLY_TIMEOUT = 0.02
+        await asyncio.wait_for(client.request_player_status("dev1"), 1.0)
+
+    async def test_basic_reply_does_not_satisfy_extended_wait(self) -> None:
+        client, _ = _connected_client("dev1")
+        client._connected.set()
+        returned: list[bool] = []
+
+        async def run() -> None:
+            await client.request_player_extended_status("dev1")
+            returned.append(True)
+
+        task = asyncio.create_task(run())
+        await asyncio.sleep(0.02)
+        await client._handle_message(_FakeMsg("device/dev1/data/status", b"{}"))
+        await asyncio.sleep(0.02)
+        self.assertFalse(returned, "extended request woke on a basic reply")
+
+        await client._handle_message(_FakeMsg("device/dev1/status/full", b"{}"))
+        await asyncio.wait_for(task, 1.0)
+        self.assertTrue(returned)
 
 
 class AccessTokenResolutionTests(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_mqtt_client.py
+++ b/tests/test_mqtt_client.py
@@ -33,18 +33,21 @@ class _FakeMsg:
 
 
 class OnConnectedStatusPushTests(unittest.IsolatedAsyncioTestCase):
-    async def test_pushes_basic_status_on_connect(self) -> None:
+    async def test_pushes_basic_then_extended_on_connect(self) -> None:
         client, broker = _connected_client("dev1")
+        client._STATUS_REPLY_TIMEOUT = 0.0  # skip the inter-request gap
 
         await client._on_connected()
 
         self.assertTrue(client.is_connected)
         topics = [call.args[0] for call in broker.publish.await_args_list]
-        # Basic only (fire-and-forget); extended would block on the reply wait
-        # before the message loop is running, so it's left to the heartbeat.
-        self.assertIn("device/dev1/command/events/request", topics)
-        self.assertIn("device/dev1/command/status/request", topics)
-        self.assertNotIn("device/dev1/command/status", topics)
+        self.assertIn("device/dev1/command/status/request", topics)  # basic
+        self.assertIn("device/dev1/command/status", topics)  # extended
+        # Basic goes out before extended (spaced by the gap, not back-to-back).
+        self.assertLess(
+            topics.index("device/dev1/command/status/request"),
+            topics.index("device/dev1/command/status"),
+        )
 
     async def test_pushes_happen_while_connected_not_swallowed(self) -> None:
         # Regression guard: `_connected` must be set before the push loop, so
@@ -52,6 +55,7 @@ class OnConnectedStatusPushTests(unittest.IsolatedAsyncioTestCase):
         # would raise YotoMQTTError before reaching the broker and the list
         # below would be empty.
         client, broker = _connected_client("dev1")
+        client._STATUS_REPLY_TIMEOUT = 0.0
         seen_connected: list[bool] = []
 
         async def record(topic, payload=None, qos=0):
@@ -66,6 +70,7 @@ class OnConnectedStatusPushTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_subscribes_every_player_before_pushing(self) -> None:
         client, broker = _connected_client("dev1", "dev2")
+        client._STATUS_REPLY_TIMEOUT = 0.0
 
         await client._on_connected()
 
@@ -91,6 +96,7 @@ class QoSTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_subscribes_at_qos_1(self) -> None:
         client, broker = _connected_client("dev1")
+        client._STATUS_REPLY_TIMEOUT = 0.0
 
         await client._on_connected()
 
@@ -181,6 +187,7 @@ class ReconnectUsesFreshTokenTests(unittest.IsolatedAsyncioTestCase):
         client = YotoMqttClient()
         client._BACKOFF_MIN = 0.0
         client._BACKOFF_MAX = 0.0
+        client._STATUS_REPLY_TIMEOUT = 0.0
 
         tokens = iter(["tok1", "tok2", "tok3"])
 

--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -672,6 +672,11 @@ class YotoClient:
         auto-reconnects on transient drops; `on_disconnect(err)` fires
         each time. Callbacks may be sync or async. Amend the set later
         with `subscribe_player_events` / `unsubscribe_player_events`.
+
+        AWS IoT enforces the access token's TTL, so each reconnect re-resolves
+        the token through `check_and_refresh_token` — the same path REST uses
+        per call. The caller just has to keep `self.token` current (refresh it
+        when self-managed, or sync it in when the OAuth lifecycle is external).
         """
         if self.token is None:
             raise YotoError("No token; authenticate before connecting MQTT")
@@ -684,7 +689,16 @@ class YotoClient:
             device_ids,
             self._on_mqtt_message,
             on_disconnect=on_disconnect,
+            token_getter=self._mqtt_access_token,
         )
+
+    async def _mqtt_access_token(self) -> str:
+        """Per-(re)connect token source for MQTT: the same `check_and_refresh_token`
+        REST goes through, so both resolve the token identically."""
+        token = await self.check_and_refresh_token()
+        if token.access_token is None:
+            raise YotoError("No access token available for MQTT auth")
+        return token.access_token
 
     async def disconnect_events(self) -> None:
         if self._mqtt is None:

--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -216,10 +216,11 @@ class YotoClient:
         ):
             _LOGGER.debug("%s - access token expired or near, refreshing", DOMAIN)
             self.token = await self._auth.refresh(self.token)
-            if self._mqtt is not None:
-                # MQTT auth uses the access token; rotate the connection
-                # while preserving the player list and callbacks.
-                await self.reconnect_events()
+            # No forced MQTT reconnect here: it would re-enter this path (the
+            # MQTT token getter calls check_and_refresh_token from inside the
+            # _run task, and reconnect_events cancels that very task). MQTT
+            # re-resolves the token on its own next (re)connect via the getter,
+            # picking up the refresh when AWS drops the socket at expiry.
         return self.token
 
     # ─── Inventory ────────────────────────────────────────────────

--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -216,11 +216,6 @@ class YotoClient:
         ):
             _LOGGER.debug("%s - access token expired or near, refreshing", DOMAIN)
             self.token = await self._auth.refresh(self.token)
-            # No forced MQTT reconnect here: it would re-enter this path (the
-            # MQTT token getter calls check_and_refresh_token from inside the
-            # _run task, and reconnect_events cancels that very task). MQTT
-            # re-resolves the token on its own next (re)connect via the getter,
-            # picking up the refresh when AWS drops the socket at expiry.
         return self.token
 
     # ─── Inventory ────────────────────────────────────────────────

--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -565,12 +565,12 @@ class YotoClient:
         await self._require_mqtt().restart(device_id)
 
     async def request_player_status(self, device_id: str) -> None:
-        """Ask the player to push a fresh `data/status` on MQTT.
+        """Ask the player to push a fresh `data/status`, returning once it
+        arrives (or after a short timeout).
 
-        Goes through MQTT (`command/status/request`); the firmware responds
-        with a `data/status` within ~150ms. Requires MQTT to be connected.
-        For the richer `status/full` payload (raw battery mV, profile, …)
-        use `request_player_extended_status`.
+        Awaiting the reply means you can chain `request_player_extended_status`
+        right after without the two racing the firmware back-to-back. Requires
+        MQTT connected.
         """
         if self._mqtt is None or not self._mqtt.is_connected:
             raise YotoError(

--- a/yoto_api/mqtt/client.py
+++ b/yoto_api/mqtt/client.py
@@ -10,7 +10,7 @@ import inspect
 import json
 import logging
 import uuid
-from typing import Awaitable, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import Awaitable, Callable, Dict, List, Optional, Set, Union
 
 import aiomqtt
 
@@ -73,8 +73,8 @@ class YotoMqttClient:
         self._on_disconnect_cb: Optional[DisconnectCallback] = None
         self._token: Optional[Token] = None
         self._token_getter: Optional[TokenGetter] = None
-        # Per (player_id, extended) reply event, so a request can await its answer.
-        self._status_acks: Dict[Tuple[str, bool], asyncio.Event] = {}
+        # Per reply-topic event, so a request can await its answer.
+        self._status_acks: Dict[str, asyncio.Event] = {}
         # volume_max per player; needed to clamp set_volume requests.
         self._volume_max: dict[str, int] = {}
 
@@ -143,8 +143,8 @@ class YotoMqttClient:
         """Unsubscribe from a player that's no longer in the family."""
         self._subscribed.discard(player_id)
         self._volume_max.pop(player_id, None)
-        self._status_acks.pop((player_id, False), None)
-        self._status_acks.pop((player_id, True), None)
+        self._status_acks.pop(f"device/{player_id}/data/status", None)
+        self._status_acks.pop(f"device/{player_id}/status/full", None)
         if not self.is_connected:
             return
         for suffix in _SUBSCRIBED_TOPICS:
@@ -165,13 +165,15 @@ class YotoMqttClient:
         so a caller can chain `request_player_extended_status` without the two
         going back-to-back."""
         await self._request_and_wait(
-            player_id, extended=False, publish=self._publish_status_request
+            f"device/{player_id}/data/status",
+            self._publish_status_request(player_id),
         )
 
     async def request_player_extended_status(self, player_id: str) -> None:
         """Refresh extended status (`status/full`), waiting for the reply."""
         await self._request_and_wait(
-            player_id, extended=True, publish=self._publish_extended_request
+            f"device/{player_id}/status/full",
+            self._publish_extended_request(player_id),
         )
 
     async def _publish_status_request(self, player_id: str) -> None:
@@ -185,15 +187,11 @@ class YotoMqttClient:
         )
 
     async def _request_and_wait(
-        self,
-        player_id: str,
-        *,
-        extended: bool,
-        publish: Callable[[str], Awaitable[None]],
+        self, reply_topic: str, publish: Awaitable[None]
     ) -> None:
-        event = self._status_acks.setdefault((player_id, extended), asyncio.Event())
+        event = self._status_acks.setdefault(reply_topic, asyncio.Event())
         event.clear()
-        await publish(player_id)
+        await publish
         try:
             await asyncio.wait_for(event.wait(), self._STATUS_REPLY_TIMEOUT)
         except asyncio.TimeoutError:
@@ -340,34 +338,33 @@ class YotoMqttClient:
         )
 
     async def _on_connected(self) -> None:
-        """Subscribe, mark the connection live, then nudge a basic status push.
-
-        Fire-and-forget: the message loop isn't consuming yet, so we can't await
-        replies here. Extended status comes from an explicit request once live.
-        """
-        for player_id in list(self._subscribed):
+        """Subscribe, mark the connection live, then refresh every player's
+        status (basic + extended) in parallel."""
+        players = list(self._subscribed)
+        for player_id in players:
             await self._subscribe_player(player_id)
         self._connected.set()
-        for player_id in list(self._subscribed):
-            try:
-                await self._publish_status_request(player_id)
-            except Exception as err:
-                _LOGGER.debug(
-                    "%s - status push at connect failed for %s: %s",
-                    DOMAIN,
-                    player_id,
-                    err,
-                )
+        await asyncio.gather(*(self._refresh_status(p) for p in players))
+
+    async def _refresh_status(self, player_id: str) -> None:
+        try:
+            await self.request_player_status(player_id)
+            await self.request_player_extended_status(player_id)
+        except Exception as err:
+            _LOGGER.debug(
+                "%s - status refresh at connect failed for %s: %s",
+                DOMAIN,
+                player_id,
+                err,
+            )
 
     async def _handle_message(self, message: aiomqtt.Message) -> None:
-        parsed = parse_message(str(message.topic), message.payload)
-        if parsed is None:
-            return
-        if isinstance(parsed, StatusPatch):
-            event = self._status_acks.get((parsed.player_id, parsed.extended))
-            if event is not None:
-                event.set()
-        if self._callback is None:
+        topic = str(message.topic)
+        event = self._status_acks.get(topic)
+        if event is not None:
+            event.set()
+        parsed = parse_message(topic, message.payload)
+        if parsed is None or self._callback is None:
             return
         try:
             await _maybe_await(self._callback(parsed))

--- a/yoto_api/mqtt/client.py
+++ b/yoto_api/mqtt/client.py
@@ -27,6 +27,8 @@ _LOGGER = logging.getLogger(__name__)
 Message = Union[EventPatch, StatusPatch, PresenceEvent]
 Callback = Callable[[Message], Union[None, Awaitable[None]]]
 DisconnectCallback = Callable[[Optional[Exception]], Union[None, Awaitable[None]]]
+# Returns a fresh access token for the MQTT password, sync or async.
+TokenGetter = Callable[[], Union[str, Awaitable[str]]]
 
 # `response` (command ACKs) also exists but the lib doesn't consume it.
 #   data/events  — playback deltas
@@ -49,6 +51,9 @@ class YotoMqttClient:
     # spamming the broker. The official app uses 15s.
     KEEPALIVE = 60
     AUTH_NAME = "PublicJWTAuthorizer"
+    # At-least-once: a QoS-0 request publish or status reply can be silently
+    # dropped on the wire. Yoto recommends QoS 1 for long-lived integrations.
+    QOS = 1
 
     # Reconnect backoff bounds.
     _BACKOFF_MIN = 1.0
@@ -62,6 +67,7 @@ class YotoMqttClient:
         self._callback: Optional[Callback] = None
         self._on_disconnect_cb: Optional[DisconnectCallback] = None
         self._token: Optional[Token] = None
+        self._token_getter: Optional[TokenGetter] = None
         # volume_max per player; needed to clamp set_volume requests.
         self._volume_max: dict[str, int] = {}
 
@@ -73,23 +79,33 @@ class YotoMqttClient:
 
     async def connect(
         self,
-        token: Token,
+        token: Optional[Token],
         player_ids: List[str],
         callback: Callback,
         on_disconnect: Optional[DisconnectCallback] = None,
+        token_getter: Optional[TokenGetter] = None,
     ) -> None:
         """Connect, subscribe for each player, and start the message loop.
 
         Returns once the first connect + subscribe completes. Raises
         `YotoMQTTError` if the first attempt fails. Subsequent drops
         trigger an auto-reconnect with exponential backoff.
+
+        The access token is the broker password and AWS IoT enforces its TTL,
+        so every (re)connect must use a current one. Pass `token_getter` (sync
+        or async) to fetch a fresh token on each connect; otherwise the static
+        `token` snapshot is reused, which only suits callers that reconnect on
+        rotation themselves.
         """
         if self._task is not None and not self._task.done():
             raise YotoMQTTError("MQTT already connected; call disconnect() first")
+        if token is None and token_getter is None:
+            raise YotoMQTTError("connect() needs a token or a token_getter")
         self._callback = callback
         self._on_disconnect_cb = on_disconnect
         self._subscribed = set(player_ids)
         self._token = token
+        self._token_getter = token_getter
         self._connected.clear()
 
         first_done = asyncio.get_running_loop().create_future()
@@ -241,7 +257,10 @@ class YotoMqttClient:
         backoff = self._BACKOFF_MIN
         while True:
             try:
-                async with self._make_client() as client:
+                # Fresh token every (re)connect: AWS IoT enforces the token TTL,
+                # so reusing a snapshot fails forever once it expires.
+                access_token = await self._current_access_token()
+                async with self._make_client(access_token) as client:
                     self._client = client
                     backoff = self._BACKOFF_MIN
                     await self._on_connected()
@@ -271,12 +290,25 @@ class YotoMqttClient:
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, self._BACKOFF_MAX)
 
-    def _make_client(self) -> aiomqtt.Client:
+    async def _current_access_token(self) -> str:
+        """Access token for the next connect: the getter (fresh per call) if
+        set, else the static snapshot from `connect()`."""
+        access_token: Optional[str]
+        if self._token_getter is not None:
+            result = self._token_getter()
+            access_token = await result if inspect.isawaitable(result) else result
+        else:
+            access_token = self._token.access_token if self._token else None
+        if not access_token:
+            raise YotoMQTTError("no access token available for MQTT auth")
+        return access_token
+
+    def _make_client(self, access_token: str) -> aiomqtt.Client:
         return aiomqtt.Client(
             hostname=self.URL,
             port=self.PORT,
             username=f"_?x-amz-customauthorizer-name={self.AUTH_NAME}",
-            password=self._token.access_token,
+            password=access_token,
             transport="websockets",
             tls_params=aiomqtt.TLSParameters(),
             keepalive=self.KEEPALIVE,
@@ -322,7 +354,7 @@ class YotoMqttClient:
         if not self.is_connected:
             raise YotoMQTTError("MQTT not connected")
         try:
-            await self._client.publish(topic, payload=payload)
+            await self._client.publish(topic, payload=payload, qos=self.QOS)
         except Exception as err:
             raise YotoMQTTError(f"MQTT publish to {topic} failed: {err}") from err
 
@@ -330,7 +362,7 @@ class YotoMqttClient:
         if self._client is None:
             return
         for suffix in _SUBSCRIBED_TOPICS:
-            await self._client.subscribe(f"device/{player_id}/{suffix}")
+            await self._client.subscribe(f"device/{player_id}/{suffix}", qos=self.QOS)
         _LOGGER.debug("%s - subscribed to player %s", DOMAIN, player_id)
 
     async def _cancel_task(self) -> None:

--- a/yoto_api/mqtt/client.py
+++ b/yoto_api/mqtt/client.py
@@ -10,7 +10,7 @@ import inspect
 import json
 import logging
 import uuid
-from typing import Awaitable, Callable, List, Optional, Set, Union
+from typing import Awaitable, Callable, Dict, List, Optional, Set, Tuple, Union
 
 import aiomqtt
 
@@ -55,6 +55,11 @@ class YotoMqttClient:
     # dropped on the wire. Yoto recommends QoS 1 for long-lived integrations.
     QOS = 1
 
+    # Wait for a status reply before the caller's next request, so chained
+    # basic+extended don't go back-to-back (which drops a reply). Replies land
+    # in ~0.4s; the gap then matches that.
+    _STATUS_REPLY_TIMEOUT = 0.5
+
     # Reconnect backoff bounds.
     _BACKOFF_MIN = 1.0
     _BACKOFF_MAX = 60.0
@@ -68,6 +73,8 @@ class YotoMqttClient:
         self._on_disconnect_cb: Optional[DisconnectCallback] = None
         self._token: Optional[Token] = None
         self._token_getter: Optional[TokenGetter] = None
+        # Per (player_id, extended) reply event, so a request can await its answer.
+        self._status_acks: Dict[Tuple[str, bool], asyncio.Event] = {}
         # volume_max per player; needed to clamp set_volume requests.
         self._volume_max: dict[str, int] = {}
 
@@ -130,12 +137,14 @@ class YotoMqttClient:
         if not self.is_connected:
             return  # picked up on next connect
         await self._subscribe_player(player_id)
-        await self.request_player_status(player_id)
+        await self._publish_status_request(player_id)
 
     async def remove_player(self, player_id: str) -> None:
         """Unsubscribe from a player that's no longer in the family."""
         self._subscribed.discard(player_id)
         self._volume_max.pop(player_id, None)
+        self._status_acks.pop((player_id, False), None)
+        self._status_acks.pop((player_id, True), None)
         if not self.is_connected:
             return
         for suffix in _SUBSCRIBED_TOPICS:
@@ -152,28 +161,43 @@ class YotoMqttClient:
     # ─── Status refresh ──────────────────────────────────────────
 
     async def request_player_status(self, player_id: str) -> None:
-        """Ask the player to push fresh `data/events` + `data/status`.
+        """Refresh basic status, waiting for the `data/status` reply (or timeout)
+        so a caller can chain `request_player_extended_status` without the two
+        going back-to-back."""
+        await self._request_and_wait(
+            player_id, extended=False, publish=self._publish_status_request
+        )
 
-        The firmware never publishes `data/status` spontaneously; this
-        is the only way to refresh the basic status over MQTT. For the
-        richer `status/full` payload use `request_player_extended_status`.
-        """
+    async def request_player_extended_status(self, player_id: str) -> None:
+        """Refresh extended status (`status/full`), waiting for the reply."""
+        await self._request_and_wait(
+            player_id, extended=True, publish=self._publish_extended_request
+        )
+
+    async def _publish_status_request(self, player_id: str) -> None:
         await self._publish(f"device/{player_id}/command/events/request")
         await self._publish(f"device/{player_id}/command/status/request")
 
-    async def request_player_extended_status(self, player_id: str) -> None:
-        """Ask the player to push its extended status (`status/full`).
-
-        Publishes `command/status` with a requestId; the firmware replies
-        on `device/{id}/status/full` with the rich payload (raw battery mV,
-        batteryLevelRaw, profile, etc.). This is the same command Yoto Cloud
-        issues behind `POST /device-v2/{id}/command/status`, but direct over
-        MQTT — no REST round-trip.
-        """
+    async def _publish_extended_request(self, player_id: str) -> None:
         await self._publish(
             f"device/{player_id}/command/status",
             json.dumps({"requestId": uuid.uuid4().hex}),
         )
+
+    async def _request_and_wait(
+        self,
+        player_id: str,
+        *,
+        extended: bool,
+        publish: Callable[[str], Awaitable[None]],
+    ) -> None:
+        event = self._status_acks.setdefault((player_id, extended), asyncio.Event())
+        event.clear()
+        await publish(player_id)
+        try:
+            await asyncio.wait_for(event.wait(), self._STATUS_REPLY_TIMEOUT)
+        except asyncio.TimeoutError:
+            pass
 
     # ─── Player commands ─────────────────────────────────────────
 
@@ -186,26 +210,26 @@ class YotoMqttClient:
             f"device/{player_id}/command/volume/set",
             json.dumps({"volume": closest_volume}),
         )
-        await self.request_player_status(player_id)
+        await self._publish_status_request(player_id)
 
     async def set_sleep_timer(self, player_id: str, seconds: int) -> None:
         await self._publish(
             f"device/{player_id}/command/sleep-timer/set",
             json.dumps({"seconds": int(seconds)}),
         )
-        await self.request_player_status(player_id)
+        await self._publish_status_request(player_id)
 
     async def card_stop(self, player_id: str) -> None:
         await self._publish(f"device/{player_id}/command/card/stop")
-        await self.request_player_status(player_id)
+        await self._publish_status_request(player_id)
 
     async def card_pause(self, player_id: str) -> None:
         await self._publish(f"device/{player_id}/command/card/pause")
-        await self.request_player_status(player_id)
+        await self._publish_status_request(player_id)
 
     async def card_resume(self, player_id: str) -> None:
         await self._publish(f"device/{player_id}/command/card/resume")
-        await self.request_player_status(player_id)
+        await self._publish_status_request(player_id)
 
     async def card_play(
         self,
@@ -228,7 +252,7 @@ class YotoMqttClient:
         await self._publish(
             f"device/{player_id}/command/card/start", json.dumps(payload)
         )
-        await self.request_player_status(player_id)
+        await self._publish_status_request(player_id)
 
     async def restart(self, player_id: str) -> None:
         await self._publish(f"device/{player_id}/command/reboot")
@@ -316,15 +340,17 @@ class YotoMqttClient:
         )
 
     async def _on_connected(self) -> None:
-        """Subscribe, mark the connection live, then push basic + extended status."""
+        """Subscribe, mark the connection live, then nudge a basic status push.
+
+        Fire-and-forget: the message loop isn't consuming yet, so we can't await
+        replies here. Extended status comes from an explicit request once live.
+        """
         for player_id in list(self._subscribed):
             await self._subscribe_player(player_id)
-        # Before the push loop: request_player_* gate on is_connected via _publish.
         self._connected.set()
         for player_id in list(self._subscribed):
             try:
-                await self.request_player_status(player_id)
-                await self.request_player_extended_status(player_id)
+                await self._publish_status_request(player_id)
             except Exception as err:
                 _LOGGER.debug(
                     "%s - status push at connect failed for %s: %s",
@@ -335,7 +361,13 @@ class YotoMqttClient:
 
     async def _handle_message(self, message: aiomqtt.Message) -> None:
         parsed = parse_message(str(message.topic), message.payload)
-        if parsed is None or self._callback is None:
+        if parsed is None:
+            return
+        if isinstance(parsed, StatusPatch):
+            event = self._status_acks.get((parsed.player_id, parsed.extended))
+            if event is not None:
+                event.set()
+        if self._callback is None:
             return
         try:
             await _maybe_await(self._callback(parsed))


### PR DESCRIPTION
Three independent MQTT reliability fixes.

**Token refresh on reconnect.** The client captured the access token once at connect and reused it on every reconnect. AWS IoT enforces the token TTL, so after ~1h the broker dropped the socket and the reconnect loop retried with a dead token forever. The token is now re-resolved on every (re)connect through `check_and_refresh_token` — the same path REST uses.

**QoS 1** on publishes and subscriptions (was QoS 0 fire-and-forget, which silently drops requests and replies).

**Serialized status requests.** The firmware drops a status reply when a basic (`data/status`) and extended (`status/full`) request land back-to-back — measured ~60% drop. `request_player_status` / `request_player_extended_status` now wait for their own reply, so chaining the two serialises them (~100%). On (re)connect the client refreshes basic + extended for every player in parallel, so extended sensors populate immediately on reload; player commands stay fire-and-forget.

No API change: `connect_events` is unchanged and HA keeps syncing `client.token` as before.