### PR TITLE
feat: refresh status when an event implies a change

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,6 +2,7 @@
 MQTT lifecycle, dynamic subscribe, settings + alarms writes, online
 state consolidation."""
 
+import asyncio
 import datetime
 import json
 import unittest
@@ -745,6 +746,80 @@ class OnlinePresenceOnEveryMqttMessageTests(_ClientTestCase):
         client, player = self._client_with_offline_player()
         await client._on_mqtt_message(EventPatch(player_id="d1", fields={"volume": 5}))
         self.assertTrue(player.is_online)
+
+
+class StatusRefreshOnEventTests(_ClientTestCase):
+    """Status fields (card_insertion_state, power_source…) aren't pushed with
+    events, so a card/streaming change or a player coming back online pulls a
+    fresh basic + extended status (spawned as a task, off the message loop)."""
+
+    def _client(self, *, online: bool = True) -> tuple[YotoClient, YotoPlayer]:
+        client = self.make_client()
+        player = YotoPlayer(device=Device(device_id="d1", name="x"))
+        player.is_online = online
+        client.players["d1"] = player
+        client._mqtt = MagicMock()
+        client._mqtt.is_connected = True
+        client._mqtt.request_player_status = AsyncMock()
+        client._mqtt.request_player_extended_status = AsyncMock()
+        return client, player
+
+    async def _drain(self, client: YotoClient) -> None:
+        await asyncio.gather(*client._event_refresh_tasks)
+
+    def _assert_refreshed(self, client: YotoClient) -> None:
+        client._mqtt.request_player_status.assert_awaited_once_with("d1")
+        client._mqtt.request_player_extended_status.assert_awaited_once_with("d1")
+
+    async def test_card_insert_refreshes(self) -> None:
+        client, _ = self._client()
+        await client._on_mqtt_message(
+            EventPatch(player_id="d1", fields={"card_id": "abc"})
+        )
+        await self._drain(client)
+        self._assert_refreshed(client)
+
+    async def test_card_remove_refreshes(self) -> None:
+        client, player = self._client()
+        player.last_event.card_id = "abc"
+        await client._on_mqtt_message(
+            EventPatch(player_id="d1", fields={"card_id": "none"})
+        )
+        await self._drain(client)
+        self._assert_refreshed(client)
+
+    async def test_streaming_change_refreshes(self) -> None:
+        client, _ = self._client()
+        await client._on_mqtt_message(
+            EventPatch(player_id="d1", fields={"streaming": True})
+        )
+        await self._drain(client)
+        self._assert_refreshed(client)
+
+    async def test_non_card_event_does_not_refresh(self) -> None:
+        client, player = self._client()
+        player.last_event.card_id = "abc"
+        await client._on_mqtt_message(EventPatch(player_id="d1", fields={"volume": 5}))
+        await self._drain(client)
+        client._mqtt.request_player_status.assert_not_awaited()
+
+    async def test_came_online_refreshes(self) -> None:
+        client, _ = self._client(online=False)
+        await client._on_mqtt_message(PresenceEvent(player_id="d1", is_online=True))
+        await self._drain(client)
+        self._assert_refreshed(client)
+
+    async def test_still_online_presence_does_not_refresh(self) -> None:
+        client, _ = self._client(online=True)
+        await client._on_mqtt_message(PresenceEvent(player_id="d1", is_online=True))
+        await self._drain(client)
+        client._mqtt.request_player_status.assert_not_awaited()
+
+    async def test_going_offline_does_not_refresh(self) -> None:
+        client, _ = self._client(online=True)
+        await client._on_mqtt_message(PresenceEvent(player_id="d1", is_online=False))
+        await self._drain(client)
+        client._mqtt.request_player_status.assert_not_awaited()
 
 
 class UpdatePlayerStatusTests(_ClientTestCase):

--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -166,6 +166,9 @@ class YotoClient:
         self._update_callback: Optional[UpdateCallback] = None
         self._disconnect_callback: Optional[DisconnectCallback] = None
         self._connected_player_ids: List[str] = []
+        # Background status-refresh tasks spawned from MQTT events (card change,
+        # came-online); tracked so they survive GC and are cancelled on close.
+        self._event_refresh_tasks: set[asyncio.Task] = set()
 
         self.token: Optional[Token] = None
         self.players: Dict[str, YotoPlayer] = {}
@@ -180,6 +183,10 @@ class YotoClient:
 
     async def close(self) -> None:
         """Tear down the MQTT task and (if owned) the aiohttp session."""
+        tasks = list(self._event_refresh_tasks)
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
         await self.disconnect_events()
         if self._owns_session and not self._session.closed:
             await self._session.close()
@@ -743,7 +750,12 @@ class YotoClient:
             # "offline" is the broker's Last-Will (the device can't publish it
             # itself), so unlike every other topic it does NOT prove presence.
             # Going offline keeps the last battery reading (don't blank it).
+            came_online = message.is_online and not player.is_online
             self._set_online(player, message.is_online)
+            # A player back online may have changed while away (card inserted,
+            # replugged); its status isn't pushed, so pull a fresh one.
+            if came_online:
+                self._schedule_status_refresh(message.player_id)
         else:
             # data/events, data/status and status/full only arrive from a live
             # device, so any of them is proof the player is online.
@@ -751,6 +763,8 @@ class YotoClient:
             if isinstance(message, StatusPatch):
                 self._apply_status_patch(player, message)
             elif isinstance(message, EventPatch):
+                prev_card = player.last_event.card_id
+                prev_streaming = player.last_event.streaming
                 self._apply_playback_event(player, message)
                 player.last_event_received_at = datetime.datetime.now(
                     datetime.timezone.utc
@@ -760,11 +774,36 @@ class YotoClient:
                 volume_max = message.fields.get("volume_max")
                 if self._mqtt is not None and volume_max is not None:
                     self._mqtt.set_volume_max(message.player_id, volume_max)
+                # card_insertion_state / active_card aren't pushed with the
+                # event, so pull a fresh status when the card or streaming flips.
+                if (
+                    player.last_event.card_id != prev_card
+                    or player.last_event.streaming != prev_streaming
+                ):
+                    self._schedule_status_refresh(message.player_id)
         if self._update_callback is not None:
             try:
                 await _maybe_await(self._update_callback(player))
             except Exception:
                 _LOGGER.exception("%s - update callback raised", DOMAIN)
+
+    def _schedule_status_refresh(self, device_id: str) -> None:
+        """An event implied a status change (card/streaming flip, came back
+        online); pull a fresh basic + extended status. Spawned as a task so the
+        message loop keeps running — otherwise the serialised requests would
+        block on replies the loop can't deliver."""
+        if self._mqtt is None or not self._mqtt.is_connected:
+            return
+        task = asyncio.create_task(self._refresh_status_after_event(device_id))
+        self._event_refresh_tasks.add(task)
+        task.add_done_callback(self._event_refresh_tasks.discard)
+
+    async def _refresh_status_after_event(self, device_id: str) -> None:
+        try:
+            await self.request_player_status(device_id)
+            await self.request_player_extended_status(device_id)
+        except YotoError:
+            pass
 
     def _apply_playback_event(self, player: YotoPlayer, patch: EventPatch) -> None:
         """Apply an MQTT events patch onto the player's `last_event` snapshot.


### PR DESCRIPTION
## What this does

Some status fields (`card_insertion_state`, `active_card`, `power_source`, Wi-Fi/SSID) come from the on-demand `data/status` / `status/full` topics, not from the `data/events` the player pushes. So after a card was inserted or removed, or a player came back online, those values stayed stale until the next periodic poll (up to a minute).

The client now pulls a fresh status as soon as it knows something changed:

- the playing card or streaming state flips (from a pushed `data/events`), or
- a player goes from offline back to online.

Both basic and extended status are refreshed, serialized so the firmware doesn't drop one of the replies. The refresh runs in a background task so it never blocks the MQTT message loop (the serialized requests need the loop free to deliver their replies); pending tasks are cancelled on `close()`.