### PR TITLE
refactor: split status and events requests

### DIFF
--- a/tests/test_mqtt_client.py
+++ b/tests/test_mqtt_client.py
@@ -41,6 +41,7 @@ class OnConnectedStatusPushTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(client.is_connected)
         topics = [call.args[0] for call in broker.publish.await_args_list]
+        self.assertIn("device/dev1/command/events/request", topics)  # playback
         self.assertIn("device/dev1/command/status/request", topics)  # basic
         self.assertIn("device/dev1/command/status", topics)  # extended
         # Basic goes out before extended (spaced by the gap, not back-to-back).
@@ -78,6 +79,43 @@ class OnConnectedStatusPushTests(unittest.IsolatedAsyncioTestCase):
         for device_id in ("dev1", "dev2"):
             self.assertIn(f"device/{device_id}/data/status", subscribed)
             self.assertIn(f"device/{device_id}/status/full", subscribed)
+
+
+class StatusEventsSplitTests(unittest.IsolatedAsyncioTestCase):
+    """`request_player_status` refreshes only `data/status`; `data/events` is
+    requested separately (the device pushes it on its own, so only connect and
+    add_player force a snapshot)."""
+
+    async def test_request_player_status_is_status_only(self) -> None:
+        client, broker = _connected_client("dev1")
+        client._connected.set()
+        client._STATUS_REPLY_TIMEOUT = 0.0
+
+        await client.request_player_status("dev1")
+
+        topics = [c.args[0] for c in broker.publish.await_args_list]
+        self.assertEqual(topics, ["device/dev1/command/status/request"])
+
+    async def test_command_does_not_request_events(self) -> None:
+        client, broker = _connected_client("dev1")
+        client._connected.set()
+
+        await client.card_stop("dev1")
+
+        topics = [c.args[0] for c in broker.publish.await_args_list]
+        self.assertIn("device/dev1/command/card/stop", topics)
+        self.assertIn("device/dev1/command/status/request", topics)
+        self.assertNotIn("device/dev1/command/events/request", topics)
+
+    async def test_add_player_requests_events_and_status(self) -> None:
+        client, broker = _connected_client()
+        client._connected.set()
+
+        await client.add_player("dev1")
+
+        topics = [c.args[0] for c in broker.publish.await_args_list]
+        self.assertIn("device/dev1/command/events/request", topics)
+        self.assertIn("device/dev1/command/status/request", topics)
 
 
 class QoSTests(unittest.IsolatedAsyncioTestCase):

--- a/yoto_api/mqtt/client.py
+++ b/yoto_api/mqtt/client.py
@@ -137,6 +137,7 @@ class YotoMqttClient:
         if not self.is_connected:
             return  # picked up on next connect
         await self._subscribe_player(player_id)
+        await self._publish_events_request(player_id)
         await self._publish_status_request(player_id)
 
     async def remove_player(self, player_id: str) -> None:
@@ -177,8 +178,10 @@ class YotoMqttClient:
         )
 
     async def _publish_status_request(self, player_id: str) -> None:
-        await self._publish(f"device/{player_id}/command/events/request")
         await self._publish(f"device/{player_id}/command/status/request")
+
+    async def _publish_events_request(self, player_id: str) -> None:
+        await self._publish(f"device/{player_id}/command/events/request")
 
     async def _publish_extended_request(self, player_id: str) -> None:
         await self._publish(
@@ -348,6 +351,7 @@ class YotoMqttClient:
 
     async def _refresh_status(self, player_id: str) -> None:
         try:
+            await self._publish_events_request(player_id)
             await self.request_player_status(player_id)
             await self.request_player_extended_status(player_id)
         except Exception as err:


### PR DESCRIPTION
`request_player_status` also fired an `events/request`, redundant since the device pushes `data/events` on its own on every playback change.

It now refreshes `data/status` only. `events/request` becomes a separate publish, kept where a fresh snapshot is actually needed (connect, `add_player`).

Commands and any periodic `request_player_status` no longer force a playback refresh, they lean on the spontaneous push. Also lets an event-triggered status refresh drop the redundant `data/events` round-trip.