### PR TITLE
feat: add has_light_sensor capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ whether data has actually been received. On top of that, `status` and
 `extended_status` carry `updated_at`: when that telemetry was current
 device-side. Gate on it if you care about freshness.
 
+## Capabilities
+
+Hardware differs by device family. `caps_for(device)` returns the
+`Capabilities` for any `Device`, falling back to v2 for unknown families:
+
+```python
+from yoto_api import caps_for
+caps = caps_for(player.device)
+caps.has_ambient_light   # ambient light ring (every family except Mini)
+caps.has_light_sensor    # ambient light sensor, gates auto display brightness (v3 only)
+```
+
 ## Common methods
 
 All public methods are async.

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -8,9 +8,13 @@ from yoto_api import Device, caps_for
 class CapabilitiesTests(unittest.TestCase):
     def test_known_families(self) -> None:
         mini = Device(device_id="x", name="Mini", device_family="mini")
-        v3 = Device(device_id="y", name="Player V3", device_family="v3")
+        v2 = Device(device_id="y", name="Player V2", device_family="v2")
+        v3 = Device(device_id="z", name="Player V3", device_family="v3")
         self.assertFalse(caps_for(mini).has_ambient_light)
         self.assertTrue(caps_for(v3).has_ambient_light)
+        self.assertTrue(caps_for(v3).has_light_sensor)
+        self.assertFalse(caps_for(v2).has_light_sensor)
+        self.assertFalse(caps_for(mini).has_light_sensor)
 
     def test_unknown_falls_back_to_v2(self) -> None:
         future = Device(device_id="z", name="?", device_family="v4")

--- a/yoto_api/capabilities.py
+++ b/yoto_api/capabilities.py
@@ -16,6 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 @dataclass(frozen=True)
 class Capabilities:
     has_ambient_light: bool
+    has_light_sensor: bool
 
 
 # Family used as a fallback when the API returns an unknown device_family.
@@ -23,10 +24,10 @@ class Capabilities:
 FAMILY_DEFAULT = "v2"
 
 _CAPABILITIES = {
-    "v1": Capabilities(has_ambient_light=True),
-    "v2": Capabilities(has_ambient_light=True),
-    "v3": Capabilities(has_ambient_light=True),
-    "mini": Capabilities(has_ambient_light=False),
+    "v1": Capabilities(has_ambient_light=True, has_light_sensor=False),
+    "v2": Capabilities(has_ambient_light=True, has_light_sensor=False),
+    "v3": Capabilities(has_ambient_light=True, has_light_sensor=True),
+    "mini": Capabilities(has_ambient_light=False, has_light_sensor=False),
 }
 
 assert FAMILY_DEFAULT in _CAPABILITIES, "FAMILY_DEFAULT must be a known family"


### PR DESCRIPTION
Adds `has_light_sensor` to `Capabilities`. Only the v3 ships the ambient light sensor, so consumers can gate the light-level sensor entity and the auto display brightness mode on it.

Documented in the README's Capabilities section.