### PR TITLE
fix: write full brightness when disabling auto-brightness

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -326,13 +326,21 @@ class SetPlayerConfigTests(_ClientTestCase):
                 day_display_brightness=80,
             )
 
-    async def test_brightness_auto_false_alone_is_noop(self) -> None:
-        # Setting auto=False without a value would mean "leave manual mode
-        # but don't change the value" — Yoto can't express that, so the
-        # lib drops it silently. The consumer has to pass a value to set
-        # manual mode.
+    async def test_brightness_auto_false_writes_full_brightness(self) -> None:
+        # The API has no standalone "auto off" — disabling auto means writing
+        # a manual value. Mirror the Yoto app and write full brightness, so a
+        # consumer (e.g. HA) only has to send the boolean.
         await self.client.set_player_config("dev1", day_display_brightness_auto=False)
-        self.client._rest.update_settings.assert_not_awaited()
+        payload = self.client._rest.update_settings.call_args.args[2]
+        self.assertEqual(payload["dayDisplayBrightness"], "100")
+
+    async def test_brightness_value_overrides_auto_false(self) -> None:
+        # An explicit value wins over the auto-off default.
+        await self.client.set_player_config(
+            "dev1", day_display_brightness_auto=False, day_display_brightness=30
+        )
+        payload = self.client._rest.update_settings.call_args.args[2]
+        self.assertEqual(payload["dayDisplayBrightness"], "30")
 
     async def test_serialize_int_rejects_string(self) -> None:
         # Make sure we don't accidentally accept str inputs for int fields.

--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -129,6 +129,11 @@ _BRIGHTNESS_PAIRS = (
     ),
 )
 
+# Auto-brightness shares its field with the manual value, so the API has no
+# standalone "off": disabling it means writing a manual value. Mirror the Yoto
+# app, which writes full brightness, so a consumer only has to send the bool.
+_BRIGHTNESS_WHEN_AUTO_OFF = 100
+
 # (preset kwarg, the raw colour field it resolves into) — the two are
 # mutually exclusive in a single call.
 _AMBIENT_PRESET_PAIRS = (
@@ -457,6 +462,8 @@ class YotoClient:
 
         For each side (day / night), `display_brightness_auto=True` and
         `display_brightness=N` are mutually exclusive in a single call.
+        `display_brightness_auto=False` alone writes full brightness
+        (matching the Yoto app), since the API has no standalone auto-off.
 
         Ambient light can be set by preset key via `day_ambient_preset` /
         `night_ambient_preset` (one of `AMBIENT_PRESET_KEYS`); the lib
@@ -500,6 +507,8 @@ class YotoClient:
                 payload[api_key] = "auto"
             elif value is not None:
                 payload[api_key] = _serialize_int(value)
+            elif auto is False:
+                payload[api_key] = _serialize_int(_BRIGHTNESS_WHEN_AUTO_OFF)
 
         for snake, value in fields.items():
             if value is None:


### PR DESCRIPTION
`day`/`night_display_brightness_auto` shares its API field with the manual value, so there's no standalone "auto off". The lib dropped a lone `auto=False`, forcing callers to also send a brightness value. It now writes full brightness (matching the Yoto app), so consumers just send the boolean.

This lets the HA integration's auto-brightness switch send only `auto=True`/`False` instead of hardcoding a value.