### PR TITLE
fix: preserve existing config when writing settings

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1014,5 +1014,79 @@ class GetCardGroupsResponseShapeTests(_ClientTestCase):
         self.assertEqual(await rest.get_card_groups(fresh_token()), [])
 
 
+class ConfigMergeTests(_ClientTestCase):
+    """`PUT /config` replaces the whole config block and the firmware
+    refills missing keys with its defaults, so every write merges onto a
+    freshly read config."""
+
+    RAW = {
+        "dayTime": "07:30",
+        "nightTime": "19:30",
+        "ambientColour": "#ff8c00",
+        "nightAmbientColour": "#40bfd9",
+        "dayDisplayBrightness": "auto",
+        "alarms": ["07:00,1,0,0,0,1"],
+    }
+
+    def _rest(self, raw=None):
+        from yoto_api.rest.client import RestClient
+
+        rest = RestClient(session=MagicMock())
+        rest._get = AsyncMock(return_value={"device": {"config": raw or self.RAW}})
+        rest._put = AsyncMock(return_value={})
+        return rest
+
+    def _sent_config(self, rest):
+        return rest._put.call_args.args[3]["config"]
+
+    async def test_untouched_keys_survive(self) -> None:
+        rest = self._rest()
+        await rest.update_settings(fresh_token(), "dev1", {"dayTime": "09:00"})
+        sent = self._sent_config(rest)
+        self.assertEqual(sent["dayTime"], "09:00")
+        for key in ("nightTime", "ambientColour", "nightAmbientColour"):
+            self.assertEqual(sent[key], self.RAW[key])
+
+    async def test_brightness_encoding_merges_on_api_key(self) -> None:
+        rest = self._rest()
+        await rest.update_settings(fresh_token(), "dev1", {"dayTime": "09:00"})
+        self.assertEqual(self._sent_config(rest)["dayDisplayBrightness"], "auto")
+
+        rest = self._rest()
+        await rest.update_settings(
+            fresh_token(), "dev1", {"dayDisplayBrightness": "80"}
+        )
+        self.assertEqual(self._sent_config(rest)["dayDisplayBrightness"], "80")
+
+    async def test_alarms_round_trip_on_config_write(self) -> None:
+        rest = self._rest()
+        await rest.update_settings(fresh_token(), "dev1", {"dayTime": "09:00"})
+        self.assertEqual(self._sent_config(rest)["alarms"], self.RAW["alarms"])
+
+    async def test_alarms_write_preserves_the_rest(self) -> None:
+        rest = self._rest()
+        await rest.update_settings(
+            fresh_token(), "dev1", {"alarms": ["08:00,1,0,0,0,1"]}
+        )
+        sent = self._sent_config(rest)
+        self.assertEqual(sent["alarms"], ["08:00,1,0,0,0,1"])
+        self.assertEqual(sent["dayTime"], "07:30")
+        self.assertEqual(sent["ambientColour"], "#ff8c00")
+
+    async def test_unmapped_key_is_preserved(self) -> None:
+        rest = self._rest({**self.RAW, "someNewFirmwareKey": "42"})
+        await rest.update_settings(fresh_token(), "dev1", {"dayTime": "09:00"})
+        self.assertEqual(self._sent_config(rest)["someNewFirmwareKey"], "42")
+
+    async def test_missing_config_block_still_writes(self) -> None:
+        from yoto_api.rest.client import RestClient
+
+        rest = RestClient(session=MagicMock())
+        rest._get = AsyncMock(return_value={})
+        rest._put = AsyncMock(return_value={})
+        await rest.update_settings(fresh_token(), "dev1", {"dayTime": "09:00"})
+        self.assertEqual(self._sent_config(rest), {"dayTime": "09:00"})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -457,8 +457,10 @@ class YotoClient:
         """Update PlayerConfig settings.
 
         Kwargs are `PlayerConfig` field names with proper Python types
-        (`datetime.time`, `int`, `bool`, ...). `None` values are
-        dropped — `PUT /config` merges, omitted fields stay unchanged.
+        (`datetime.time`, `int`, `bool`, ...). `None` values are dropped.
+        Omitted fields stay unchanged: `PUT /config` replaces the whole
+        config block, so the lib reads the current one and merges client
+        side (see `RestClient.update_settings`).
 
         For each side (day / night), `display_brightness_auto=True` and
         `display_brightness=N` are mutually exclusive in a single call.
@@ -534,8 +536,9 @@ class YotoClient:
     async def set_alarms(self, device_id: str, alarms: List[Alarm]) -> None:
         """Replace the device's full alarm list.
 
-        Yoto's `PUT /config` treats the list as a replacement, so always
-        pass every alarm you want to keep.
+        The `alarms` list is written wholesale, so always pass every alarm
+        you want to keep. The rest of the config is preserved (see
+        `RestClient.update_settings`).
         """
         token = await self.check_and_refresh_token()
         payload = encode_alarms_payload(alarms)

--- a/yoto_api/rest/client.py
+++ b/yoto_api/rest/client.py
@@ -108,10 +108,30 @@ class RestClient:
 
     # ─── Settings writes ──────────────────────────────────────────
 
+    async def get_raw_config(self, token: Token, device_id: str) -> Dict[str, Any]:
+        """Unparsed so `update_settings` can merge onto it: a
+        parse-then-reserialise drops the keys the lib doesn't map yet.
+        """
+        response = await self._get(
+            token,
+            endpoints.device_config(device_id),
+            f"get player {device_id} raw config",
+        )
+        raw = (response.get("device") or {}).get("config")
+        return raw if isinstance(raw, dict) else {}
+
     async def update_settings(
         self, token: Token, device_id: str, payload: Dict[str, Any]
     ) -> None:
-        body = {"deviceId": device_id, "config": payload}
+        """Merge `payload` (API keys) into the device's current config.
+
+        `PUT /config` replaces the whole block and the firmware refills
+        missing keys with its defaults, so a partial write resets every
+        setting it omits. Re-read on each write rather than cached: the
+        config also changes from the Yoto app.
+        """
+        raw = await self.get_raw_config(token, device_id)
+        body = {"deviceId": device_id, "config": {**raw, **payload}}
         await self._put(
             token,
             endpoints.device_config(device_id),


### PR DESCRIPTION
`PUT /config` replaces the whole `config` block instead of merging it, and the firmware refills the missing keys with its defaults. Since `update_settings` only sent the changed keys, every write reset the rest of the config: changing an ambient colour sent `dayTime` back to 07:30, changing a time sent both colours back to red.

`update_settings` now reads the current raw config and merges onto it before the PUT, so `set_player_config` and `set_alarms` are both covered without duplication. The merge is on the raw dict rather than a re-serialised `PlayerConfig`, to preserve the keys the lib doesn't map yet.

Verified by tests only, not yet exercised against a real player. Worth confirming the firmware accepts a full config re-sent as-is, `alarms` included.
