### PR TITLE
fix: read card category from library metadata

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -104,6 +104,29 @@ class UpdateAllPlayerInfoToleranceTests(_ClientTestCase):
         self.assertIsNotNone(client.players["also_good"].info_refreshed_at)
 
 
+class UpdateLibraryTests(_ClientTestCase):
+    async def test_reads_card_category_from_metadata_category(self) -> None:
+        client = self.make_client()
+        client.token = fresh_token()
+        client._rest.get_card_library = AsyncMock(
+            return_value={
+                "cards": [
+                    {
+                        "cardId": "card-1",
+                        "card": {
+                            "title": "Story card",
+                            "metadata": {"category": "stories"},
+                        },
+                    }
+                ]
+            }
+        )
+
+        await client.update_library()
+
+        self.assertEqual(client.library["card-1"].category, "stories")
+
+
 class MqttSurfaceTests(_ClientTestCase):
     async def test_connect_events_passes_getter_reading_live_token(self) -> None:
         # The MQTT client gets a token_getter that re-reads self.token on every

--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -335,7 +335,7 @@ class YotoClient:
             card.title = get_child_value(item, "card.title")
             card.description = get_child_value(item, "card.metadata.description")
             card.author = get_child_value(item, "card.metadata.author")
-            card.category = get_child_value(item, "card.metadata.stories")
+            card.category = get_child_value(item, "card.metadata.category")
             card.cover_image_large = get_child_value(item, "card.metadata.cover.imageL")
             card.series_order = get_child_value(item, "card.metadata.cover.seriesorder")
             card.series_title = get_child_value(item, "card.metadata.cover.seriestitle")


### PR DESCRIPTION
## Summary

- read `Card.category` from `card.metadata.category`
- add a regression test for the family-library response shape

## Why

`YotoClient.update_library()` currently reads `card.metadata.stories`, but card metadata and the `Card.category` model contract use `card.metadata.category`. The current lookup therefore leaves `Card.category` as `None` for library cards.

## Testing

- regression test failed before the parser change (`None != "stories"`)
- targeted regression test passes
- full non-e2e suite: 139 passed
- all pre-commit hooks pass, including Ruff, formatting, codespell, and mypy
