### PR TITLE
feat: Allow registration of a token refresh notification hook

### DIFF
--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -11,7 +11,6 @@ MQTT background task are torn down cleanly:
         await client.connect_events([device_id], on_update=cb)
 """
 
-from yoto_api.models import player
 import asyncio
 import datetime
 import logging

--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -169,7 +169,7 @@ class YotoClient:
         self,
         client_id: Optional[str] = None,
         session: Optional[aiohttp.ClientSession] = None,
-        refresh_hook: Optional[Callable[[str], None]] = None,
+        refresh_hook: Optional[Callable[[Token], None]] = None,
     ) -> None:
         self._owns_session = session is None
         self._session = session or aiohttp.ClientSession()
@@ -237,8 +237,8 @@ class YotoClient:
         ):
             _LOGGER.debug("%s - access token expired or near, refreshing", DOMAIN)
             self.token = await self._auth.refresh(self.token)
-            if self._refresh_hook and self.token.refresh_token:
-                self._refresh_hook(self.token.refresh_token)
+            if self._refresh_hook:
+                self._refresh_hook(self.token)
         return self.token
 
     # ─── Inventory ────────────────────────────────────────────────

--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -169,10 +169,12 @@ class YotoClient:
         self,
         client_id: Optional[str] = None,
         session: Optional[aiohttp.ClientSession] = None,
+        refresh_hook: Optional[Callable[[str], None]] = None,
     ) -> None:
         self._owns_session = session is None
         self._session = session or aiohttp.ClientSession()
         self._auth = Auth(self._session, client_id=client_id)
+        self._refresh_hook = refresh_hook
         self._rest = RestClient(self._session)
         self._mqtt: Optional[YotoMqttClient] = None
         self._update_callback: Optional[UpdateCallback] = None
@@ -235,6 +237,8 @@ class YotoClient:
         ):
             _LOGGER.debug("%s - access token expired or near, refreshing", DOMAIN)
             self.token = await self._auth.refresh(self.token)
+            if self._refresh_hook and self.token.refresh_token:
+                self._refresh_hook(self.token.refresh_token)
         return self.token
 
     # ─── Inventory ────────────────────────────────────────────────

--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -216,6 +216,11 @@ class YotoClient:
 
     async def device_code_flow_complete(self, auth_result: dict) -> Token:
         self.token = await self._auth.poll_for_token(auth_result)
+        if self._refresh_hook is not None:
+            try:
+                await _maybe_await(self._refresh_hook(self.token))
+            except Exception:
+                _LOGGER.exception("%s - refresh hook callback raised", DOMAIN)
         return self.token
 
     async def check_and_refresh_token(self) -> Token:

--- a/yoto_api/client.py
+++ b/yoto_api/client.py
@@ -11,6 +11,7 @@ MQTT background task are torn down cleanly:
         await client.connect_events([device_id], on_update=cb)
 """
 
+from yoto_api.models import player
 import asyncio
 import datetime
 import logging
@@ -40,6 +41,7 @@ from .rest.requests import encode_alarms_payload
 _LOGGER = logging.getLogger(__name__)
 
 UpdateCallback = Callable[[YotoPlayer], Union[None, Awaitable[None]]]
+RefreshTokenCallback = Callable[[Token], Union[None, Awaitable[None]]]
 DisconnectCallback = Callable[[Optional[Exception]], Union[None, Awaitable[None]]]
 
 
@@ -169,7 +171,7 @@ class YotoClient:
         self,
         client_id: Optional[str] = None,
         session: Optional[aiohttp.ClientSession] = None,
-        refresh_hook: Optional[Callable[[Token], None]] = None,
+        refresh_hook: Optional[RefreshTokenCallback] = None,
     ) -> None:
         self._owns_session = session is None
         self._session = session or aiohttp.ClientSession()
@@ -237,8 +239,11 @@ class YotoClient:
         ):
             _LOGGER.debug("%s - access token expired or near, refreshing", DOMAIN)
             self.token = await self._auth.refresh(self.token)
-            if self._refresh_hook:
-                self._refresh_hook(self.token)
+            if self._refresh_hook is not None:
+                try:
+                    await _maybe_await(self._refresh_hook(self.token))
+                except Exception:
+                    _LOGGER.exception("%s - refresh hook callback raised", DOMAIN)
         return self.token
 
     # ─── Inventory ────────────────────────────────────────────────


### PR DESCRIPTION
Authentication can be configured by providing a refresh token, but that token itself can be refreshed. This changes allows registration of a callback that is triggered when the authentication token is update and a refresh token is present.